### PR TITLE
Change default ftrivial-auto-var-init to zero

### DIFF
--- a/package/develop/gcc/default-trivial-auto-var-init-zero.patch
+++ b/package/develop/gcc/default-trivial-auto-var-init-zero.patch
@@ -1,0 +1,11 @@
+--- gcc-12.1.0/gcc/common.opt.orig	2022-05-06 23:02:24.694391477 +0200
++++ gcc-12.1.0/gcc/common.opt	2022-05-06 23:31:35.599714720 +0200
+@@ -3141,7 +3141,7 @@
+ Enable copy propagation of scalar-evolution information.
+ 
+ ftrivial-auto-var-init=
+-Common Joined RejectNegative Enum(auto_init_type) Var(flag_auto_var_init) Init(AUTO_INIT_UNINITIALIZED) Optimization
++Common Joined RejectNegative Enum(auto_init_type) Var(flag_auto_var_init) Init(AUTO_INIT_ZERO) Optimization
+ -ftrivial-auto-var-init=[uninitialized|pattern|zero]	Add initializations to automatic variables.
+ 
+ Enum


### PR DESCRIPTION
Change the default behaviour from ftrivial-auto-var-init=unitialized to ftrivial-auto-var-init=zero.
This will fill variables with 0x00, which tends to provide a safer state for bugs (e.g. pointers are NULL, strings are NUL filled, and sizes and indices are 0)

Tested-By: daGraveR <graver@freedom.nl>