### PR TITLE
Changed egrep to grep -E due to deprecation and because its used else…

### DIFF
--- a/scripts/Bootstrap
+++ b/scripts/Bootstrap
@@ -35,7 +35,9 @@ done
 
 mkdir -p /var/adm/flists /etc/profile.d
 
+
 echo "Essential bootstrap done. To finalize a minimal t2/homebrew, simply first run:"
+echo "  scripts/Config"
 echo "	scripts/Emerge-Pkg -deps=none xz coreutils findutils tar pkgconfig"
 echo ""
 echo "To use Subversion, also install:"

--- a/scripts/Config
+++ b/scripts/Config
@@ -21,7 +21,9 @@ if [ -z "${lines:=$LINES}" -o -z "${columns:=$COLUMNS}" ]; then
 	[ -z "$columns" -o "$columns" -le 0 ] 2> /dev/null && columns=80
 fi
 
-eval "$(egrep '^sdever=' scripts/parse-config)"
+eval "$(grep -E '^sdever=' scripts/parse-config)"
+# Replaced with grep -E , arch is forcing to use grep -E instead 
+#eval "$(egrep '^sdever=' scripts/parse-config)"
 
 config=default
 do_config_cycle=0


### PR DESCRIPTION
Changed `egrep` to `grep -E` due to deprecation and because its used else where. arch was forcing this

```sh
egrep: warning: egrep is obsolescent; using grep -E
```

First time build seems to need a configuration (gives error `Error - old config is not supported by new config`), by default, atleast for arch this needs to be run while building ->
```sh
scripts/Config
```
Added this command on the "first time run" for Bootstrap script

Build Env - 
```
Linux 6.1.44-1-MANJARO #1 SMP PREEMPT_DYNAMIC Wed Aug  9 09:02:26 UTC 2023 x86_64 GNU/Linux
```
(x86-64)