### PR TITLE
Bump Maven 1 to version 1.1

### DIFF
--- a/package/java/maven1/maven1.desc
+++ b/package/java/maven1/maven1.desc
@@ -26,7 +26,7 @@
 
 [L] APL
 [S] Stable
-[V] 1.0.2
+[V] 1.1
 [P] X -----5---9 800.100
 
-[D] 9253f3fbb2ddd0afaf91b3ab3a920f9fc2c04141df87f98cfd0d3a6c maven-1.0.2.tar.bz2 http://www.eu.apache.org/dist/maven/binaries/
+[D] 53cdeed503a9694be48d0ded05cf178f2223b8402c607b48304d0446 maven-1.1.tar.bz2 http://archive.apache.org/dist/maven/binaries/


### PR DESCRIPTION
In order to package the optional dependencies from LibreOffice, Maven is needed.
As the Maven packages in T2 SDE are a bit outdated, I decided to give them some love.

This Pull Request bumps the version of Maven 1 to 1.1.