### PR TITLE
Update glib to 2.79.1

### DIFF
--- a/package/gnome/glib/glib.desc
+++ b/package/gnome/glib/glib.desc
@@ -25,11 +25,11 @@
 
 [L] LGPL
 [S] Stable
-[V] 2.78.4
+[V] 2.79.1
 [P] X 0-2--5---9 110.900
 
 #[O] var_append GCC_WRAPPER_REMOVE ' ' '-Werror=format=2' # TODO: remove w/ update!
 
 [CV-URL] https://download.gnome.org/sources/glib/cache.json
 [CV-FLAGS] ODD-STABLE
-[D] d414fd6af9bd90e38d064f23dfd49de85ca4a6bda5ab4b801d88c743 glib-2.78.4.tar.xz https://download.gnome.org/sources/glib/2.78/
+[D] c984033bfc02673a13a0b7573bde19cf0fba69fbe0358614531dfc00 glib-2.79.1.tar.xz https://download.gnome.org/sources/glib/2.79/

--- a/package/python/packaging/packaging.desc
+++ b/package/python/packaging/packaging.desc
@@ -1,0 +1,20 @@
+[I] Core utilities for Python packages
+
+[T] This library provides utilities that implement the interoperability specifications which have clearly one correct behaviour (eg: PEP 440)
+[T] or benefit greatly from having a single shared implementation (eg: PEP 425).
+[T] The packaging project includes the following: version handling, specifiers, markers, requirements, tags, utilities.
+
+[U] https://github.com/pypa/packaging
+
+[A] Donald Stufft <donald@stufft.io>
+[M] The T2 Project
+
+[C] extra/development
+[L] APL
+[L] BSD
+
+[S] Beta
+[V] 23.2
+[P] X -----5---9 300.000
+
+[D] d54eeff8c7ca86980528f4132f258d54  packaging-23.2.tar.gz https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/


### PR DESCRIPTION
**Issue:**
The latest version of Python in the trunk is 3.12, glib is on 2.78.4.
When compiling glib 2.78.4 while having Python 3.12, it complains about a missing `distutils` module. This module was removed in 3.12.

**Solution:**
So, I decided to update glib to 2.79.1. Now the build process is complaining about a missing Python package called `packaging`. Thus I added it as a new package. 🙂 
Everything compiles, `packaging` as well as `glib`.

I have one question, though: `packaging` uses both the APL and BSD license. Can I add two licenses to the .desc file?