### PR TITLE
Update libvncserver and x11vnc

### DIFF
--- a/package/x11/libvncserver/libvncserver.desc
+++ b/package/x11/libvncserver/libvncserver.desc
@@ -22,10 +22,10 @@
 
 [L] GPL
 [S] Stable
-[V] 0.9.9
+[V] 0.9.14s
 [P] X -----5---9 171.900
 
 [CV-FLAGS] ODD-STABLE
 
 [O] var_append confopt ' ' "--enable-shared"
-[D] 8eea2eef8b0d0b875457cd7b8c300de327a1360c4a877ce3eeb0019d LibVNCServer-0.9.9.tar.gz http://dl.sourceforge.net/sourceforge/libvncserver/
+[D] cbedb5bf505116b4dc09c806186be90386c4e74b745c1b4e5364f804 LibVNCServer-0.9.14.tar.gz https://github.com/LibVNC/libvncserver/archive/refs/tags/

--- a/package/x11/x11vnc/fix-fnocommon-build.patch
+++ b/package/x11/x11vnc/fix-fnocommon-build.patch
@@ -1,0 +1,30 @@
+unchanged:
+--- x11vnc-0.9.16/src/util.c.orig	2019-01-05 14:22:11.000000000 +0100
++++ x11vnc-0.9.16/src/util.c	2024-02-12 21:29:15.724961668 +0100
+@@ -47,6 +47,9 @@
+ #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+ MUTEX(x11Mutex);
+ MUTEX(scrollMutex);
++MUTEX(clientMutex);
++MUTEX(inputMutex);
++MUTEX(pointerMutex);
+ #endif
+
+ int nfix(int i, int n);
+only in patch2:
+unchanged:
+--- x11vnc-0.9.16/src/util.h.orig	2019-01-05 14:22:11.000000000 +0100
++++ x11vnc-0.9.16/src/util.h	2024-02-12 21:29:15.724961668 +0100
+@@ -102,9 +102,9 @@
+ #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+ extern MUTEX(x11Mutex);
+ extern MUTEX(scrollMutex);
+-MUTEX(clientMutex);
+-MUTEX(inputMutex);
+-MUTEX(pointerMutex);
++extern MUTEX(clientMutex);
++extern MUTEX(inputMutex);
++extern MUTEX(pointerMutex);
+ #endif
+
+ #define X_INIT INIT_MUTEX(x11Mutex)

--- a/package/x11/x11vnc/x11vnc.desc
+++ b/package/x11/x11vnc/x11vnc.desc
@@ -25,10 +25,10 @@
 
 [L] GPL
 [S] Stable
-[V] 0.9.13
+[V] 0.9.16
 [P] X -----5---9 171.900
 
 [O] var_append confopt ' ' '--with-system-libvncserver'
 
 [CV-FLAGS] ODD-STABLE
-[D] c9d07dc8c3d8b2ccfd8f22a7f22f1e2ce788a494a9306c72e4297853 x11vnc-0.9.13.tar.gz http://dl.sourceforge.net/sourceforge/libvncserver/
+[D] 3ca717087e539f7df59ea780729c84f0d75e24b270d700232986c45f 0.9.16.tar.gz https://github.com/LibVNC/x11vnc/archive/refs/tags/


### PR DESCRIPTION
This PR updates libvncserver to 0.9.14 and x11vnc to 0.9.16.
x11vnc needs an additional patch in order to build. I found a patch in Gentoo Bugzilla, it also works for T2 SDE 🙂 

Here is a screenshot from VNC, showing my freshly built VNC setup:
<img width="963" alt="Bildschirmfoto 2024-02-12 um 21 15 52" src="https://github.com/rxrbln/t2sde/assets/23658248/ee1454ff-3bb9-4dab-bd34-98d59913f53b">
