### PR TITLE
Add patch for libreoffice 7.6.4.1

### DIFF
--- a/package/office/libreoffice/python312-configure.patch
+++ b/package/office/libreoffice/python312-configure.patch
@@ -1,0 +1,44 @@
+--- libreoffice-7.6.4.1/configure.vanilla	2024-02-11 11:16:55.991980479 +0100
++++ libreoffice-7.6.4.1/configure	2024-02-11 11:26:46.752049007 +0100
+@@ -29261,7 +29261,7 @@
+   # Factor out some code duplication into this shell variable.
+   am_python_setup_sysconfig="\
+ import sys
+-# Prefer sysconfig over distutils.sysconfig, for better compatibility
++# Prefer sysconfig over sysconfig, for better compatibility
+ # with python 3.x.  See automake bug#10227.
+ try:
+     import sysconfig
+@@ -29716,7 +29716,7 @@
+   # Factor out some code duplication into this shell variable.
+   am_python_setup_sysconfig="\
+ import sys
+-# Prefer sysconfig over distutils.sysconfig, for better compatibility
++# Prefer sysconfig over sysconfig, for better compatibility
+ # with python 3.x.  See automake bug#10227.
+ try:
+     import sysconfig
+@@ -30179,7 +30179,7 @@
+   # Factor out some code duplication into this shell variable.
+   am_python_setup_sysconfig="\
+ import sys
+-# Prefer sysconfig over distutils.sysconfig, for better compatibility
++# Prefer sysconfig over sysconfig, for better compatibility
+ # with python 3.x.  See automake bug#10227.
+ try:
+     import sysconfig
+@@ -30300,10 +30300,10 @@
+
+   fi
+
+-        python_include=`$PYTHON -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('INCLUDEPY'));"`
+-        python_version=`$PYTHON -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('VERSION'));"`
+-        python_libs=`$PYTHON -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('LIBS'));"`
+-        python_libdir=`$PYTHON -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('LIBDIR'));"`
++        python_include=`$PYTHON -c "import sysconfig; print(sysconfig.get_config_var('INCLUDEPY'));"`
++        python_version=`$PYTHON -c "import sysconfig; print(sysconfig.get_config_var('VERSION'));"`
++        python_libs=`$PYTHON -c "import sysconfig; print(sysconfig.get_config_var('LIBS'));"`
++        python_libdir=`$PYTHON -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'));"`
+         if test -z "$PKG_CONFIG"; then
+             PYTHON_CFLAGS="-I$python_include"
+             PYTHON_LIBS="-L$python_libdir -lpython$python_version $python_libs"


### PR DESCRIPTION
This PR adds a patch which fixes the build for LibreOffice 7.6.4.1.
LibreOffice wants to use "distutils", which is deprecated in Python 3.12. The patch replaces `distutils.sysconfig` with `sysconfig`.