### PR TITLE
Enable ethernet support for the MLX5-driver

### DIFF
--- a/architecture/share/linux-net.conf.m4
+++ b/architecture/share/linux-net.conf.m4
@@ -38,6 +38,7 @@ dnl
 CONFIG_8139TOO=m
 CONFIG_FORCEDETH=m
 CONFIG_E1000=m
+CONFIG_MLX5_CORE_EN=y
 
 dnl Enable some categories so drivers are enabled as modules
 dnl


### PR DESCRIPTION
Added CONFIG_MLX5_CORE_EN=y to make sure the MLX5-driver has support for ethernet

Since it's part of the MLX5-module, this has to be set as '=y'