### PR TITLE
linux-header.desc: correct the URL to v6.x

### DIFF
--- a/package/kernel/linux-header/linux-header.desc
+++ b/package/kernel/linux-header/linux-header.desc
@@ -38,4 +38,4 @@
 [P] X 01-------9 100.300
 
 [CV-FLAGS] NO-AUTO
-[D] ad66943573ec86a5098b6208ae2129376c98ae77eab5b230e9a2e9d8 linux-6.6.tar.xz http://cdn.kernel.org/pub/linux/kernel/v5.x/
+[D] ad66943573ec86a5098b6208ae2129376c98ae77eab5b230e9a2e9d8 linux-6.6.tar.xz http://cdn.kernel.org/pub/linux/kernel/v6.x/


### PR DESCRIPTION
Version 6 is in another location /v6.x/