### PR TITLE
Added rootflags= mount options to initrd

### DIFF
--- a/package/base/mkinitrd/initrdinit.sh
+++ b/package/base/mkinitrd/initrdinit.sh
@@ -48,6 +48,7 @@ fi
 
 # get the root device, init, early swap
 [ -e /proc/cmdline ] && cmdline="$(< /proc/cmdline)"
+rootflags="rootflags= $cmdline" rootflags=${rootflags##*rootflags=} rootflags=${rootflags%% *}
 root="root= $cmdline" root=${root##*root=} root=${root%% *}
 init="init= $cmdline" init=${init##*init=} init=${init%% *}
 swap="swap= $cmdline" swap=${swap##*swap=} swap=${swap%% *}
@@ -61,6 +62,8 @@ for v in $cmdline; do
     rw)	mountopt="rw${mountopt#r[ow]}" ;;
     esac
 done
+
+[ -n "$rootflags" ] && mountopt="$rootflags"
 
 # diskless network root?
 addr="${root%:*}"


### PR DESCRIPTION
This patch adds support for `rootflags=...` boot option that will be used to mount root filesystem.

Use case: specifying BTRFS subvolume where I installed T2 Linux (I use one big shared BTRFS partition and install each Linux distribution to its dedicated subvolume).

Here is example menu entry for grub - when T2 is installed into subvolume `T2-ROOT`:

```
menuentry "T2/Linux" {
	linux /T2-ROOT/boot/vmlinuz root=/dev/disk/by-uuid/KEEP_YOUR_UUID_HERE ro rootflags=subvol=T2-ROOT
	initrd /T2-ROOT/boot/initrd2.zst
}
```

If you like to install T2 into BTRFS subvolume you can follow my guide on: https://github.com/hpaluch/hpaluch.github.io/wiki/T2SDE#installing-on-btrfs-sub-volume
