### PR TITLE
Fix unresolved crc32 when building rust 1.85.0

### DIFF
--- a/package/rust/rustc/rustdriver-libz-fix.patch
+++ b/package/rust/rustc/rustdriver-libz-fix.patch
@@ -1,0 +1,6 @@
+--- rustc-1.85.0-src/compiler/rustc_driver_impl/build.rs.orig	2025-03-07 08:23:55.930000000 +0100
++++ rustc-1.85.0-src/compiler/rustc_driver_impl/build.rs	2025-03-07 08:22:18.863368826 +0100
+@@ -0,0 +1,3 @@
++fn main() {
++    println!("cargo:rustc-link-lib=dylib=z");
++}


### PR DESCRIPTION
Here is patch that fixes `rustc 1.85.0` build error:
```
....
   Compiling rustc_interface v0.0.0 (/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/compiler/rustc_interface)
   Compiling rustc_driver_impl v0.0.0 (/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/compiler/rustc_driver_impl)
   Compiling rustc_driver v0.0.0 (/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/compiler/rustc_driver)
error: linking with `gcc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1/lib64/rustlib/x86_64-unknown-linux-gnu/bin:/us
r/src/t2-src/build/default-25-svn-generic-x86-64-nocona-linux/TOOLCHAIN/native/wrapper:/usr/src/t2-src/build/default-25-svn-generic-x86-64-nocona-linux/TOOLCHAIN/native/bin:/
opt/xfce4/sbin:/opt/mozilla/sbin:/opt/java/sbin:/opt/gnome/sbin:/opt/xfce4/bin:/opt/mozilla/bin:/opt/libreoffice/bin:/opt/java/bin:/opt/gnome/bin:/usr/X11/sbin:/usr/X11/bin:/
usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" VSLANG="1033" "gcc" "-m64" "/usr/src/t2-src/src.rustc.250307.074659.19382/tmp/rustc1H7xyW/symbols.o" "<1 object f
iles omitted>" "-Wl,--as-needed" "-Wl,-Bdynamic" "/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-g
nu/release/deps/librustc_driver-21c1949fb3d9c236.so" "-Wl,-Bstatic" "/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1/lib6
4/rustlib/x86_64-t2-linux-gnu/lib/{libcompiler_builtins-cd1b390526793d0d.rlib}" "-Wl,-Bdynamic" "-lstdc++" "-ldl" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-W
l,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.
0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/build/psm-ded234b09198c5a3/out" "-L" "/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/build/blake3-2412bd62df9daff7/out" "-L" "/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/build/blake3-2412bd62df9daff7/out" "-L" "/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/build/rustc_llvm-a91322e9dc4e4fe2/out" "-L" "/usr/lib64" "-L" "/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1/lib64/rustlib/x86_64-t2-linux-gnu/lib" "-o" "/usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/deps/rustc_main-8f77f04bc3300b6e" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs" "-Wl,-z,origin" "-Wl,-rpath,$ORIGIN/../lib64"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/lib64/gcc/x86_64-t2-linux-gnu/14.2.0/../../../../x86_64-t2-linux-gnu/bin/ld: /usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/deps/librustc_driver-21c1949fb3d9c236.so: undefined reference to `crc32'
          /usr/lib64/gcc/x86_64-t2-linux-gnu/14.2.0/../../../../x86_64-t2-linux-gnu/bin/ld: /usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/deps/librustc_driver-21c1949fb3d9c236.so: undefined reference to `compressBound'
          /usr/lib64/gcc/x86_64-t2-linux-gnu/14.2.0/../../../../x86_64-t2-linux-gnu/bin/ld: /usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/deps/librustc_driver-21c1949fb3d9c236.so: undefined reference to `compress2'
          /usr/lib64/gcc/x86_64-t2-linux-gnu/14.2.0/../../../../x86_64-t2-linux-gnu/bin/ld: /usr/src/t2-src/src.rustc.250307.074659.19382/rustc-1.85.0-src/build/x86_64-unknown-linux-gnu/stage1-rustc/x86_64-t2-linux-gnu/release/deps/librustc_driver-21c1949fb3d9c236.so: undefined reference to `uncompress'
          collect2: error: ld returned 1 exit status
```

NOTE: I always remove `/opt/rust` before build using:
```shell
mine -r rustc
```
because that causes even early infamous error:
```
   Compiling shlex v1.3.0                                                                                                                                             
error[E0463]: can't find crate for `std`    
```

How to reproduce:
- initial distribution 25.1: `t2-25.1-x86-64-base-wayland-glibc-gcc-nocona.iso` using
  default full install (`base-wayland`)
- updating system with:
```shell
mine -r rustc # remove /opt/rust to avoid crate std error
cd /usr/src/t2-src
t2 up
t2 config # just Exit
# build requirements:
# jinja2: required by udev
t2 install perl perl-xml-parser python python-installer setuptools pip jinja2 ninja meson libtool libxml autoconf
t2 upgrade
# will fail on rustc with librustc_driver-21c1949fb3d9c236.so: undefined reference to `crc32'
```

When I apply fix and rerun:
```shell
t2 install rustc
/opt/rust/bin/rustc --version
  rustc 1.85.0 (4d91de4e4 2025-02-17) (built from a source tarball)
mine -q rustc
  rustc 1.85.0 25-svn
```
It will build and install without error.

Disclaimer: I did not yet build Firefox and other rust dependencies to verify that it really works.
