### PR TITLE
Kmod - properly disable man-pages - typo in parameter

### DIFF
--- a/package/base/kmod/kmod.conf
+++ b/package/base/kmod/kmod.conf
@@ -15,7 +15,7 @@ if atstage toolchain; then
 	xprefix=${arch_target}-
 	var_append confopt " " "--program-transform-name='s,^,$xprefix,'"
 else
-	atstage cross && var_append confopt " " --disable-manpage
+	atstage cross && var_append confopt " " --disable-manpages
 	bindir=$sbindir
 fi
 


### PR DESCRIPTION
Kmod package now requires `scdoc` unconditionally.

It is caused by typo in configure parameter (passing `--disable-manpage`, but `--disable-manpages` expected 
as can be seen in error message:

```
configure: error: *** scdoc needed for building manpages. Either install it or pass --disable-manpages
```
Notice `s` at the end of parameter.

Tested on following SVN  repository:
```shell
$ svn info | grep '^Last Change'
Last Changed Author: notag
Last Changed Rev: 75040
Last Changed Date: 2025-03-13 22:39:45 +0100 (Thu, 13 Mar 2025)
```