### PR TITLE
Update Zig to 0.14.0 and Ncdu to 2.8 to fix build errors + LLVM 20 breaks Zig build requirements

### DIFF
--- a/package/contrib/ncdu/ncdu.desc
+++ b/package/contrib/ncdu/ncdu.desc
@@ -16,8 +16,8 @@
 [C] extra/base
 [F] CROSS
 
-[V] 2.0.1
+[V] 2.8
 [L] MIT
 [S] Stable
 
-[D] efb0dfd0031c6f26d8c37d3e3cd902b1464205ba002b647c6552c440 ncdu-2.0.1.tar.gz http://dev.yorhel.nl/download/
+[D] 8ad071ca805c18684a05b140fd9ba114a9a473eaca7e8d3a7418a5a2 ncdu-2.8.tar.gz http://dev.yorhel.nl/download/

--- a/package/zig/zig/zig.desc
+++ b/package/zig/zig/zig.desc
@@ -24,7 +24,7 @@
 
 [L] MIT
 [S] Beta
-[V] 0.14.0-dev.2546+0ff0bdb4a
+[V] 0.14.0
 [P] X ?----5---9 109.300
 
-[D] aaf78e8b90ae3ef7b0085f4c4b9166cfc61576ab22e5df17e9e272a8 zig-0.14.0-dev.2546+0ff0bdb4a.tar.xz https://ziglang.org/builds/
+[D] 7e20d0132b51c84c472a8e2c58cff4d8b59839418f5e47f13b779e4c zig-0.14.0.tar.xz https://ziglang.org/builds/


### PR DESCRIPTION
Here is patch that makes 2 version upgrades to again build Ncdu (full screen disk usage utility) without error.

1. Ncdu upgraded from 2.0.1 to 2.8 to fix several major incompatibilities with Zig 0.14dev+ - contributed
   by "BratishkaErik" on https://code.blicky.net/yorhel/ncdu/pulls/254 - these are included in Ncdu 2.8 release
3. Zig upgraded from `0.14.0-dev.2546+0ff0bdb4a` to `0.14.0` to support `std.debug.FullPanic` on which Ncdu 2.8 now depends.

> [!WARNING]
> 1. Above Zig upgrade may break other packages depending on it!
> 1. With latest SVN Trunk it is no longer possible to build any version of Zig, because Zig requires LLVM 19.x while current Trunk upgrades to LLVM 20.1.0. I don't know how to resolve this problem. There is PR  in Zig project at https://github.com/ziglang/zig/pull/22780 but is is not finished (Draft).

So I'm currently using this dirty trick to build Zig and Ncdu under latest trunk:
- I install T2 version 25.1 from `t2-25.1-x86-64-base-wayland-glibc-gcc-nocona.iso`
- I update *sources* with `t2 up` but I don't upgrade LLVM in system (so it stays on `19.1.7`)
- finally I run:

```shell
t2 install zig
t2 install ncdu
```

*Please consider above risks before merging this PR.*