### PR TITLE
Cross-build of linux-firmware will fail when GNU parallel creates /root/.parallel on 1st run

### DIFF
--- a/package/firmware/linux-firmware/parallel-avoid-write-to-home.patch
+++ b/package/firmware/linux-firmware/parallel-avoid-write-to-home.patch
@@ -1,0 +1,20 @@
+--- linux-firmware-20250311/copy-firmware.sh.vanilla	2025-03-23 08:51:17.159999833 +0100
++++ linux-firmware-20250311/copy-firmware.sh	2025-03-23 08:51:28.559999832 +0100
+@@ -111,7 +111,7 @@
+     fi
+ done
+ if [ "$num_jobs" -gt 1 ]; then
+-    parallel -j"$num_jobs" -a "$parallel_args_file"
++    PARALLEL_HOME=${TMPDIR:-/tmp} parallel -j"$num_jobs" -a "$parallel_args_file"
+     echo > "$parallel_args_file" # prepare for next run
+ fi
+ 
+@@ -138,7 +138,7 @@
+     fi
+ done
+ if [ "$num_jobs" -gt 1 ]; then
+-    parallel -j"$num_jobs" -a "$parallel_args_file"
++    PARALLEL_HOME=${TMPDIR:-/tmp} parallel -j"$num_jobs" -a "$parallel_args_file"
+ fi
+ 
+ # Verify no broken symlinks


### PR DESCRIPTION
When these 3 conditions are met:

1. cross-build with more than 1 parallel job (typcally `auto` is used)
2. GNU parallel was not yet run as root, so path `/root/.parallel/*` does not exist yet
3. it is 1st cross-build of `linux-firmware` (typically `1-linux-firmware` job)

In such case that first cross-build will fail with error:
```
08:49:47 1/197 Building 1-firmware/linux-firmware (20250311) ~12s                                                       
  Building in src.linux-firmware.crosscli.250323.084947.14061, with 9 threads                                           
  Writing output to $root/var/adm/logs/1-linux-firmware.out                                                             
! Now run "make dedup" to de-duplicate any firmware files                                                               
! Creating file list and doing final adaptions ...                                                                      
! Created file outside basedir: /root/.parallel                                                                         
! base #1: /usr/src/t2-src                                  
! base #2: /usr/src/t2-src/build/crosscli-25-svn-generic-x86-64-nocona-cross-linux                              
! Created file outside basedir: /root/.parallel/tmp                                                                     
! Created file outside basedir: /root/.parallel/tmp/sshlogin                                                            
! Created file outside basedir: /root/.parallel/tmp/sshlogin/t2-clean                                                   
! removed '/usr/src/t2-src/build/crosscli-25-svn-generic-x86-64-nocona-cross-linux/var/adm/logs/1-linux-firmware.log'
  +00:00:47 Aborted building firmware/linux-firmware                                   
```

It is because under hood is used `GNU parallel` that normally creates configuration files under `/root/.parallel` which is forbidden when cross-building.

So I created patch that will instruct `parallel` to rather use `$TMPDIR` or fallback `/tmp` which is permitted in cross-build.

This patch is potentially related to #225  (it should fix sometimes rarely undected error when building `1-linux-firmware`).