### PR TITLE
* Fixing dead homepage links

### DIFF
--- a/package/audio/audacious-plugins/audacious-plugins.desc
+++ b/package/audio/audacious-plugins/audacious-plugins.desc
@@ -8,7 +8,7 @@
 
 [T] Plugins for audacious.
 
-[U] http://audacious.nenolod.net/
+[U] https://audacious-media-player.org/
 
 [A] William Pitcock <nenolod@nenolod.net>
 [A] Mohammed Sameer <msameer@foolab.org>

--- a/package/audio/audacious/audacious.desc
+++ b/package/audio/audacious/audacious.desc
@@ -8,7 +8,7 @@
 
 [T] A music player based on bmp and xmms.
 
-[U] http://audacious.nenolod.net/
+[U] https://audacious-media-player.org/
 
 [A] William Pitcock <nenolod@nenolod.net>
 [A] Mohammed Sameer <msameer@foolab.org>

--- a/package/audio/aumix/aumix.desc
+++ b/package/audio/aumix/aumix.desc
@@ -12,7 +12,7 @@
 [T] non-interactively, and can store all settings in a file. It works with
 [T] the OSS API.
 
-[U] http://jpj.net/~trevor/aumix.html
+[U] https://sourceforge.net/projects/aumix/
 
 [A] Trevor Johnson <trevor@jpj.net>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/audio/bacterium/bacterium.desc
+++ b/package/audio/bacterium/bacterium.desc
@@ -35,7 +35,7 @@
 [T] However - this package also includes the 'bacterium_gui' program which
 [T] can be used for creating *.synth files and running BacteriuM over them.
 
-[U] http://members.ping.de/~stefan/
+[U] https://web.archive.org/web/20020802232654/http://members.ping.de/~stefan/
 
 [A] Stefan Fendt <stefan@lionfish.ping.de> {Author of BacteriuM}
 [A] Claire Xenia Wolf <claire@clairexen.net> {Author of BacteriuM_GUI)

--- a/package/audio/bladeenc/bladeenc.desc
+++ b/package/audio/bladeenc/bladeenc.desc
@@ -13,7 +13,7 @@
 [T] BladeEnc doesn't have a nice, user-friendly interface like mpegEnc, but it
 [T] is more than three times faster.
 
-[U] http://bladeenc.mp3.no/skeleton/news.html
+[U] https://web.archive.org/web/20061005064502/http://bladeenc.mp3.no:80/
 
 [A] Tord Jansson <tord.jansson@swipnet.se>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/audio/bmp/bmp.desc
+++ b/package/audio/bmp/bmp.desc
@@ -10,7 +10,7 @@
 [T] with a powerful, yet easy-to-use remote API using DBus, while also providing
 [T] a skinned, yet easy and understandable user interface with the core GUI.
 
-[U] http://bmpx.beep-media-player.org/
+[U] https://web.archive.org/web/20071003012502/http://bmpx.beep-media-player.org/site/BMPx_Homepage
 
 [A] Milosz Derezynski <internalerror@gmail.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/base/acdctl/acdctl.desc
+++ b/package/base/acdctl/acdctl.desc
@@ -11,7 +11,7 @@
 [T] Apple Cinema Display. Acdctl works on any system with libusb support by
 [T] directly manipulating the display's USB HID interface.
 
-[U] http://www.technocage.com/~caskey/acdctl/
+[U] https://web.archive.org/web/20060109033241/http://www.technocage.com/~caskey/acdctl/
 
 [A] Caskey L. Dickson <caskey@technocage.com>
 [M] Rene Rebe <rene@t2-project.org>
@@ -23,4 +23,4 @@
 [S] Stable
 [V] 1.1
 
-[D] f2350aceaeb1fd126c990533638bab59fab44e2d030e4881bd429a5c acdctl-1.1.tar.bz2 http://www.technocage.com/~caskey/acdctl/download/
+[D] f2350aceaeb1fd126c990533638bab59fab44e2d030e4881bd429a5c acdctl-1.1.tar.bz2 https://gentoo.uls.co.za:8443/distfiles/9d/

--- a/package/base/crash/crash.desc
+++ b/package/base/crash/crash.desc
@@ -11,7 +11,7 @@
 [A] David Anderson
 [M] Rene Rebe <rene@t2-project.org>
 
-[U] http://people.redhat.com/anderson/
+[U] https://crash-utility.github.io/
 
 [C] base/tool
 [F] CROSS

--- a/package/boot/arcboot/arcboot.desc
+++ b/package/boot/arcboot/arcboot.desc
@@ -10,7 +10,7 @@
 [T] kernel files from both ext2 and ext3 filesystems. At this time it is
 [T] functional on the SGI IP22 and IP32.
 
-[U] https://www.linux-mips.org/wiki/Arcboot
+[U] https://honk.sigxcpu.org/piki/projects/arcboot/
 
 [A] Guido Guenther <agx@sigxcpu.org>
 [M] Rene Rebe <rene@exactcode.de>

--- a/package/boot/arcload/arcload.desc
+++ b/package/boot/arcload/arcload.desc
@@ -10,7 +10,7 @@
 [T] Therefore, it currently supports: SGI Indy, SGI Origin, SGI Indigo2 R10000,
 [T] SGI Octane and SGI O2.
 
-[U] https://www.linux-mips.org/wiki/ARCLoad
+[U] https://web.archive.org/web/20221002210224/https://www.linux-mips.org/wiki/ARCLoad
 
 [A] Stanislaw Skowronek
 [M] Rene Rebe <rene@exactcode.de>

--- a/package/boot/colo/colo.desc
+++ b/package/boot/colo/colo.desc
@@ -10,7 +10,7 @@
 [T] limitations in the original loader. It can boot from disk or over a
 [T] network via TFTP or NFS and DHCP. 
 
-[U] https://www.colonel-panic.org/cobalt-mips/
+[U] https://web.archive.org/web/20250419165403/http://colonel-panic.org/cobalt-mips/
 
 [A] Peter Horton <pdh@colonel-panic.org>
 [M] Rene Rebe <rene@exactcode.de>

--- a/package/contrib/beep/beep.desc
+++ b/package/contrib/beep/beep.desc
@@ -13,7 +13,7 @@
 [T] Of course, it has no notion of what's interesting, but it's real good
 [T] at that notifying part.
 
-[U] http://www.johnath.com/beep/
+[U] https://github.com/spkr-beep/beep/
 
 [A] Johnathan Nightingale <johnath@johnath.com>
 [M] Marian Aldenhoevel <marian.aldenhoevel@mba-software.de>

--- a/package/contrib/crore/crore.desc
+++ b/package/contrib/crore/crore.desc
@@ -10,7 +10,7 @@
 [T] Hare designed to be run without a filesystem, fast and as light on system
 [T] resources as possible in that order.
 
-[U] https://sr.ht/~ajwh/crore/
+[U] https://github.com/aetxyz/crore
 
 [A] Adam House
 [M] NoTag <notag@t2sde.org>

--- a/package/develop/apr_memcache/apr_memcache.desc
+++ b/package/develop/apr_memcache/apr_memcache.desc
@@ -10,7 +10,7 @@
 [T] It provides pooled client connections and is thread safe,
 [T] making it perfect for use inside Apache Modules.
 
-[U] http://www.outoforder.cc/projects/libs/apr_memcache/
+[U] https://www.outoforder.cc/projects/libs/apr_memcache/
 
 [A] outoforder.cc <http://www.outoforder.cc>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/bacon/bacon.desc
+++ b/package/develop/bacon/bacon.desc
@@ -17,7 +17,7 @@
 [T] platforms (including 64bit environments), while trying to revive the days
 [T] of the good old BASIC.
 
-[U] https://www.basic-converter.org/
+[U] https://chiselapp.com/user/bacon/repository/bacon/home
 
 [A] Peter van Eerten <peter@remove-no-spam.basic-converter.org>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/bacon_runtime/bacon_runtime.desc
+++ b/package/develop/bacon_runtime/bacon_runtime.desc
@@ -12,7 +12,7 @@
 [T] platforms (including 64bit environments), while trying to revive the days
 [T] of the good old BASIC.
 
-[U] https://www.basic-converter.org/
+[U] https://chiselapp.com/user/bacon/repository/bacon/home
 
 [A] Peter van Eerten <peter@remove-no-spam.basic-converter.org>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/bazaar/bazaar.desc
+++ b/package/develop/bazaar/bazaar.desc
@@ -12,7 +12,7 @@
 [T] without requiring special permission from the branches that they
 [T] branched from.
 
-[U] http://bazaar-vcs.org/
+[U] https://launchpad.net/bzr
 
 [A] Martin Pool <mbp@sourcefrog.net>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/bdiff/bdiff.desc
+++ b/package/develop/bdiff/bdiff.desc
@@ -9,7 +9,7 @@
 [T] Bdiff is a simple and small program to do what the very common utilities
 [T] diff and patch do with text files, but also works with binary files.
 
-[U] http://www.webalice.it/g_pochini/bdiff/
+[U] https://web.archive.org/web/20070523110307/http://www.webalice.it/g_pochini/bdiff/
 
 [A] Giuliano Pochini <pochini@denise.shiny.it>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/develop/binwalk/binwalk.desc
+++ b/package/develop/binwalk/binwalk.desc
@@ -9,7 +9,7 @@
 [T] Binwalk is a fast, easy to use tool for analyzing and extracting firmware
 [T] images.
 
-[U] http://binwalk.org/
+[U] https://github.com/ReFirmLabs/binwalk/
 
 [A] Craig Heffner
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/develop/boehm-gc/boehm-gc.desc
+++ b/package/develop/boehm-gc/boehm-gc.desc
@@ -12,7 +12,7 @@
 [T] by a number of programming language implementations that use C as
 [T] intermediate code.
 
-[U] http://www.hpl.hp.com/personal/Hans_Boehm/gc/
+[U] https://hboehm.info/gc/
 
 [A] Hans-J. Boehm <Hans_Boehm@hp.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/bufferpool/bufferpool.desc
+++ b/package/develop/bufferpool/bufferpool.desc
@@ -10,7 +10,7 @@
 [T] felix. It provides a nice way to store rtp packets efficiently and
 [T] share them across applications.
 
-[U] http://live.polito.it
+[U] https://web.archive.org/web/20101231010339/http://lscube.org/projects/bufferpool
 
 [A] Alessandro Molina <amol.wrk@gmail.com>
 [A] Dario Gallucci <dario.gallucci@polito.it>

--- a/package/develop/calltree/calltree.desc
+++ b/package/develop/calltree/calltree.desc
@@ -11,7 +11,7 @@
 [T] collection of input files and builds a graph that represents the static
 [T] call structure of the files.
 
-[U] http://developer.berlios.de/projects/calltree/
+[U] https://web.archive.org/web/20091226005854/http://developer.berlios.de/projects/calltree/
 
 [A] Joerg Schilling <js@cs.tu-berlin.de>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/develop/clip/clip.desc
+++ b/package/develop/clip/clip.desc
@@ -17,7 +17,7 @@
 [T] based on TCP/IP sockets, object data base utils and functions library,
 [T] and more.
 
-[U] http://www.itk.ru/english/index.shtml
+[U] https://web.archive.org/web/20080716062237/http://www.itk.ru/english/index.shtml
 
 [A] Uri Khnykin <uri@itk.ru>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/cogito/cogito.desc
+++ b/package/develop/cogito/cogito.desc
@@ -11,7 +11,7 @@
 [T] generally smoother user experience than the "raw" Core GIT itself and indeed
 [T] many other version control systems.
 
-[U] http://git.or.cz/
+[U] https://web.archive.org/web/20150523055517/http://git.or.cz/cogito/
 
 [A] Petr Baudis <pasky@suse.cz>
 [M] Lars Kuhtz <lars@t2-project.org>

--- a/package/develop/coral/coral.desc
+++ b/package/develop/coral/coral.desc
@@ -11,7 +11,7 @@
 [T] to develop editors for other modeling languages and to implement
 [T] MDA and QVT-like model transformations.
 
-[U] http://mde.abo.fi/tools/Coral/
+[U] https://web.archive.org/web/20050207111503/http://mde.abo.fi/tools/Coral/
 
 [A] Ivan Porres <iporres@abo.fi>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/ctalk/ctalk.desc
+++ b/package/develop/ctalk/ctalk.desc
@@ -15,7 +15,7 @@
 [T] is also available separately, and the package includes sample programs
 [T] and documentation.
 
-[U] http://www.ctalklang.org/
+[U] https://sourceforge.net/projects/ctalk/
 
 [A] thx1132 <ctalk@ctalklang.org>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/cunit/cunit.desc
+++ b/package/develop/cunit/cunit.desc
@@ -10,7 +10,7 @@
 [T] running unit tests in C. It provides C programmers a basic testing
 [T] functionality with a flexible variety of user interfaces.
 
-[U] http://cunit.sourceforge.nett/index.html/
+[U] https://cunit.sourceforge.net/
 
 [A] Anil Kumar AUTHORS Jerry St.Clair <anilsaharan@users.sourceforge.net>
 [M] Roger Mason <rmason@mun.ca>

--- a/package/develop/cvsps/cvsps.desc
+++ b/package/develop/cvsps/cvsps.desc
@@ -14,7 +14,7 @@
 [T] of committed patchsets, restrict by author, date range, files affected,
 [T] branches affected. CVSps can generate a diff of a given patchset.
 
-[U] http://www.cobite.com/cvsps/
+[U] https://github.com/andreyvit/cvsps
 
 [A] David Mansfield <fm@dm.cobite.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/develop/cwiid/cwiid.desc
+++ b/package/develop/cwiid/cwiid.desc
@@ -15,7 +15,7 @@
 [T] Nintendo Wiimote, including an event-based API, an event/mouse/joystick
 [T] driver, and GUI/control panel.
 
-[U] http://www.wiili.org/index.php/CWiid
+[U] https://github.com/abstrakraft/cwiid/
 
 [A] L. Donnie Smith <cwiid@abstrakraft.org>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/dictionary/aspell-de/aspell-de.desc
+++ b/package/dictionary/aspell-de/aspell-de.desc
@@ -14,7 +14,7 @@
 [T] This dRock backage doesn't contain the original package from,
 [T] but the pre-packed version from the aspell site ...
 
-[U] http://lisa.goe.net/~bjacke/igerman98/
+[U] https://j3e.de/ispell/igerman98/
 
 [A] Bjoern Jacke <bjoern.jacke@gmx.de>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/dictionary/aspell-fr/aspell-fr.desc
+++ b/package/dictionary/aspell-fr/aspell-fr.desc
@@ -12,7 +12,7 @@
 [T] This dRock backage doesn't contain the original package from,
 [T] but the pre-packed version from the aspell site ...
 
-[U] http://perso.wanadoo.fr/remi.vanicat/aspell/index-en.html
+[U] http://aspellfr.free.fr/aspell/
 
 [A] Remi Vanica
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/filesystem/ataidle/ataidle.desc
+++ b/package/filesystem/ataidle/ataidle.desc
@@ -11,7 +11,7 @@
 [T] APM, and acoustic level settings. It can also show details about the
 [T] installed devices.
 
-[U] http://www.cran.org.uk/bruce/software/ataidle.php
+[U] https://web.archive.org/web/20080223081629/http://www.cran.org.uk/bruce/software/ataidle.php
 
 [A] Bruce Cran <bruce@cran.org.uk>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/filesystem/cdi2iso/cdi2iso.desc
+++ b/package/filesystem/cdi2iso/cdi2iso.desc
@@ -9,7 +9,7 @@
 [T] The command line program cdi2iso converts DiscJuggler image to the
 [T] standard ISO-9660 format.
 
-[U] http://developer.berlios.de/projects/cdi2iso/
+[U] https://sourceforge.net/projects/cdi2iso.berlios/
 
 [A] Salvatore Santagati <salsan@users.berlios.de>
 [M] Nagy Karoly Gabriel <nagy.karoly@x5.ro>

--- a/package/filesystem/cdrtools/cdrtools.desc
+++ b/package/filesystem/cdrtools/cdrtools.desc
@@ -13,7 +13,7 @@
 [T] mkisofs is effectively a pre-mastering program to generate
 [T] the iso9660 filesystem (= cd-rom filesystem).
 
-[U] http://www.fokus.gmd.de/research/cc/glone/employees/joerg.schilling/private/cdrecord.html
+[U] https://codeberg.org/schilytools/schilytools/
 
 [A] Joerg Schilling <schilling@fokus.gmd.de>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/filesystem/ceph/ceph.desc
+++ b/package/filesystem/ceph/ceph.desc
@@ -9,7 +9,7 @@
 [T] Open source distributed file system capable of managing many
 [T] petabytes of storage with ease.
 
-[U] http://ceph.com
+[U] https://ceph.io/en/
 
 [A] Sage Weil <sage@newdream.net>
 [A] Yehuda Sadeh-Weinraub <yehudasa@gmail.com>

--- a/package/filesystem/cramfsswap/cramfsswap.desc
+++ b/package/filesystem/cramfsswap/cramfsswap.desc
@@ -15,7 +15,7 @@
 [T] Cramfsswap provides a solution by allowing to swap the endianess of a
 [T] cramfs filesystem.
 
-[U] http://labs.fqdn.org/page/cramfsswap
+[U] https://github.com/julijane/cramfsswap
 
 [A] Michael Holzt <kju@debian.org>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/games/4dtris/4dtris.desc
+++ b/package/games/4dtris/4dtris.desc
@@ -10,7 +10,7 @@
 [T] is extended to a 4D field, which has to filled up by the gamer with 4D
 [T] hyper cubes. The software is written in C with OpenGL and GLUT.
 
-[U] http://illusions.hu/4dtris
+[U] https://github.com/simzer/4dtris
 
 [A] Laszlo Simon <laszlo.simon@gmail.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/gnome/at-spi/at-spi.desc
+++ b/package/gnome/at-spi/at-spi.desc
@@ -10,7 +10,7 @@
 [T] The assistive technolgy service provider interface of the GNOME
 [T] accesssibility interface library:
 
-[U] http://developer.gnome.org/projects/gap/GNOME-Accessibility.html
+[U] https://wiki.gnome.org/Accessibility
 
 [A] The GNOME Project <gnome-devel-list@gnome.org>
 [M] Susanne Klaus <vadja@gmx.de>

--- a/package/gnome/at-spi2-core/at-spi2-core.desc
+++ b/package/gnome/at-spi2-core/at-spi2-core.desc
@@ -9,7 +9,7 @@
 [T] The assistive technolgy service provider interface of the GNOME
 [T] accesssibility interface library:
 
-[U] http://developer.gnome.org/projects/gap/GNOME-Accessibility.html
+[U] https://wiki.gnome.org/Accessibility/
 
 [A] The GNOME Project <gnome-devel-list@gnome.org>
 [M] Rene Rebe <rene@exactcode.de>

--- a/package/gnome/brasero/brasero.desc
+++ b/package/gnome/brasero/brasero.desc
@@ -10,7 +10,7 @@
 [T] It is designed to be as simple as possible and has some unique features
 [T] to enable users to create their discs easily and quickly.
 
-[U] http://perso.orange.fr/bonfire
+[U] https://wiki.gnome.org/Apps/Brasero
 
 [A] Philippe Rouquier <bonfire-app@wanadoo.fr>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/gnome/cellwriter/cellwriter.desc
+++ b/package/gnome/cellwriter/cellwriter.desc
@@ -15,7 +15,7 @@
 [T] for digitizer noise, differing stroke order, direction, and number of
 [T] strokes. Unicode support enables you to write in any language.
 
-[U] http://risujin.org/cellwriter
+[U] https://github.com/risujin/cellwriter/
 
 [A] Risujin <risujin@risujin.org>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/gnome/clutter-gtk/clutter-gtk.desc
+++ b/package/gnome/clutter-gtk/clutter-gtk.desc
@@ -10,7 +10,7 @@
 [T] We hope with further work in the future clutter-gtk will
 [T] also allow the reverse, namely embedding GTK in Clutter
 
-[U] https://www.clutter-project.org/
+[U] https://blogs.gnome.org/clutter/
 
 [A] The GTK+ Team
 [M] Gerardo Di Iorio <arete74@gmail.com>

--- a/package/gnome/clutter/clutter.desc
+++ b/package/gnome/clutter/clutter.desc
@@ -9,7 +9,7 @@
 [T] Clutter is an open source software library for creating portable, fast,
 [T] visually rich and animated graphical user interfaces.
 
-[U] https://www.clutter-project.org/
+[U] https://blogs.gnome.org/clutter/
 
 [A] The GTK+ Team
 [M] Gerardo Di Iorio <arete74@gmail.com>

--- a/package/graphic/aalib/aalib.desc
+++ b/package/graphic/aalib/aalib.desc
@@ -32,4 +32,4 @@
 [V] 1.4rc5
 [P] X -----5---9 127.900
 
-[D] 87387eed0db18c9affc9f0d15628d3b6c21846088c1bacfeb50238d7 aalib-1.4rc5.tar.gz http://dl.sourceforge.net/sourceforge/aa-project/
+[D] 87387eed0db18c9affc9f0d15628d3b6c21846088c1bacfeb50238d7 aalib-1.4rc5.tar.gz https://sourceforge.net/projects/aa-project/files/aa-lib/1.4rc5/

--- a/package/graphic/agg/agg.desc
+++ b/package/graphic/agg/agg.desc
@@ -10,7 +10,7 @@
 [T] engine that produces in-memory pixel images of vectorial data and is
 [T] written in industrial standard C++.
 
-[U] https://www.antigrain.com/
+[U] https://sourceforge.net/projects/agg/
 
 [A] Maxim Shemanarev <mcseem@antigrain.com>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/graphic/celestia/celestia.desc
+++ b/package/graphic/celestia/celestia.desc
@@ -11,7 +11,7 @@
 [T] the galaxy. Visit over 100,000 stars, 100 solar system bodies, and all
 [T] known extrasolar planets.
 
-[U] http://www.shatters.net/celestia/
+[U] https://celestiaproject.space/
 
 [A] Chris Laurel
 [M] The T2 Project <t2@t2-project.org>

--- a/package/graphic/colorcorrect/colorcorrect.desc
+++ b/package/graphic/colorcorrect/colorcorrect.desc
@@ -13,7 +13,7 @@
 [T] you tweak the controls further after setting a value. Also has an built-in
 [T] vectorscope.
 
-[U] http://pippin.gimp.org/plug-ins/color_correct/index.html
+[U] https://web.archive.org/web/20081212114923/http://pippin.gimp.org/plug-ins/color_correct/index.html
 
 [A] Michael Natterer <mitch@gimp.org>
 [A] Kevin Turner <acapnotic@users.sourceforge.net>

--- a/package/graphic/cthumb/cthumb.desc
+++ b/package/graphic/cthumb/cthumb.desc
@@ -15,7 +15,7 @@
 [T] you can have several annotations per picture. cthumb will generate
 [T] several versions of the page, for each annotation type.
 
-[U] https://cthumb.sourceforge.net/ project homepage
+[U] https://web.archive.org/web/20161009151909/http://cthumb.sourceforge.net/
 
 [A] Carlos Puchol <cpg@users.sourceforge.net>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/java/apache-ant/apache-ant.desc
+++ b/package/java/apache-ant/apache-ant.desc
@@ -25,7 +25,7 @@
 . $base/package/*/*/java-conf.in NO_AUTO_DETECT
 
 [D] 96ad992ce92676e9b203c4229e0ea2129184612e424fcef6f71afc82 apache-ant-1.10.15-src.tar.xz http://www.apache.org/dist/ant/source/
-[D] 51a8e2f845056935fe9a6d8d56641cfb2e0040b7a89d799b1133c961 junit3.8.2.zip http://dl.sourceforge.net/sourceforge/junit/
+[D] 51a8e2f845056935fe9a6d8d56641cfb2e0040b7a89d799b1133c961 junit3.8.2.zip http://sourceforge.net/projects/junit/files/junit/3.8.2/
 
 # Use jikes for faster compilation if it is available.
 if pkginstalled jikes; then

--- a/package/java/continuum/continuum.desc
+++ b/package/java/continuum/continuum.desc
@@ -9,7 +9,7 @@
 [T] Continuum is a continous integration server for building Java
 [T] based projects.
 
-[U] http://maven.apache.org/continuum/
+[U] https://continuum.apache.org/
 
 [A] Apache Maven Continuum team
 [M] Minto van der Sluis <Minto@T2-Project.org>

--- a/package/kde3/arts/arts.desc
+++ b/package/kde3/arts/arts.desc
@@ -14,7 +14,7 @@
 [T] with the GUI of the system, using the modules - generators, effects
 [T] and output - connected to each other.
 
-[U] https://www.arts-project.org/
+[U] https://web.archive.org/web/20060202044949/http://arts-project.org/
 
 [A] Stefan Westerfeld <stefan@space.twc.de>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/network/0install/0install.desc
+++ b/package/network/0install/0install.desc
@@ -12,7 +12,7 @@
 [T] Caching makes this as fast as running a normal application after
 [T] the first time, and allows off-line use.
 
-[U] http://zero-install.sourceforge.net/install.html
+[U] https://0install.net/
 
 [A] Thomas Leonard
 [M] Omer James Hickman <james_hickman@email.com>

--- a/package/network/acx100/acx100.desc
+++ b/package/network/acx100/acx100.desc
@@ -27,4 +27,4 @@
 autoextract=0
 custmain="true"
 
-[D] 30b1956a517062a8385db1946940306d054b2594017ce79f0a117646 acx-20080210.tar.bz2 http://dl.sourceforge.net/acx100/
+[D] 30b1956a517062a8385db1946940306d054b2594017ce79f0a117646 acx-20080210.tar.bz2 https://sourceforge.net/projects/acx100/files/acx100_old/20080210/

--- a/package/network/bbc_provided/bbc_provided.desc
+++ b/package/network/bbc_provided/bbc_provided.desc
@@ -8,7 +8,7 @@
 
 [T] Network utilities: ipcalc, or, and, dotquad
 
-[U] http://?
+[U] https://distro.ibiblio.org/quirky/quirky6/sources/t2/april/
 
 [A] unknown
 [M] Barry Kauler <bkauler@gmail.com>

--- a/package/network/ccrtp/ccrtp.desc
+++ b/package/network/ccrtp/ccrtp.desc
@@ -21,7 +21,7 @@
 [T] as for passing RTP telephony events. Recent builds of GNU ccRTP are also
 [T] available for building handheld softphone clients using Open Embedded.
 
-[U] http://wiki.gnutelephony.org/index.php/GNU_ccRTP
+[U] https://www.gnu.org/software/ccrtp/
 
 [A] David Sugar <dyfet@gnutelephony.org>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/network/centericq/centericq.desc
+++ b/package/network/centericq/centericq.desc
@@ -15,7 +15,7 @@
 [T] Centericq is a text mode menu- and window-driven IM interface that
 [T] supports the ICQ2000, Yahoo!, AIM, MSN, IRC and Jabber protocols.
 
-[U] http://konst.org.ua/en/centericq
+[U] https://web.archive.org/web/20120502075950/http://konst.org.ua/en/centericq
 [A] konst <konst@konst.org.ua>
 
 [M] Martin Baum <martin.baum@berlin.de>

--- a/package/office/antiword/antiword.desc
+++ b/package/office/antiword/antiword.desc
@@ -11,7 +11,7 @@
 [T] Antiword converts the binary files from Word 2, 6, 7, 97, 2000
 [T] and 2002 to plain text and to PostScript TM.
 
-[U] http://www.winfield.demon.nl/
+[U] https://web.archive.org/web/20220121050627/http://www.winfield.demon.nl
 
 [A] Adri van Os
 [M] The T2 Project <t2@t2-project.org>

--- a/package/office/aqbanking/aqbanking.desc
+++ b/package/office/aqbanking/aqbanking.desc
@@ -10,7 +10,7 @@
 [T] banking is provided via backends (currently only HBCI is
 [T] supported).
 
-[U] https://www.aquamaniac.de/sites/aqbanking/index.php
+[U] https://www.aquamaniac.de/rdm/projects/aqbanking/
 
 [A] Martin Preuss <martin@libchipcard.de>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/printing/cups-samba/cups-samba.desc
+++ b/package/printing/cups-samba/cups-samba.desc
@@ -8,7 +8,7 @@
 
 [T] CUPS Postscript driver to be shared by samba
 
-[U] http://www.cups.org/windows/
+[U] https://web.archive.org/web/20080710083114/http://www.cups.org/windows/
 
 [A] Easy Software Products
 [M] The T2 Project <t2@t2-project.org>

--- a/package/scientific/alliance/alliance.desc
+++ b/package/scientific/alliance/alliance.desc
@@ -16,7 +16,7 @@
 [T] research projects such as the 875 000 transistors StaCS superscalar
 [T] microprocessor and 400 000 transistors IEEE Gigabit HSL Router.
 
-[U] http://www-asim.lip6.fr/recherche/alliance/
+[U] https://coriolis.lip6.fr/
 
 [A] ASIM department of LIP6 laboratory of the Pierre et Marie Curie University
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/security/amap/amap.desc
+++ b/package/security/amap/amap.desc
@@ -11,7 +11,7 @@
 [T] It also identifies non-ascii based applications. This is achieved by sending
 [T] trigger packets, and looking up the responses in a list of response strings.
 
-[U] https://thc.org/thc-amap/
+[U] https://github.com/hackerschoice/THC-Archive
 
 [A] van Hauser and DJ RevMoon / THC <amap-dev@thc.org>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/security/axtls/axtls.desc
+++ b/package/security/axtls/axtls.desc
@@ -15,7 +15,7 @@
 [T] renegotiation, highly configurable compile-time options, and interfaces
 [T] for C#, VB. NET, Java, and Perl. It also implements a Web server.
 
-[U] http://axtls.cerocclub.com.au/
+[U] https://sourceforge.net/projects/axtls/
 
 [A] Cameron Rich <cameronrich@yahoo.com>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/security/cracklib/cracklib.desc
+++ b/package/security/cracklib/cracklib.desc
@@ -11,7 +11,7 @@
 [T] really, but you only need to use one of them) which may be used in a
 [T] "passwd"-like program.
 
-[U] https://sourceforge.net/projects/cracklib
+[U] https://sourceforge.net/projects/cracklib/
 
 [A] Nathan Neulinger <nneul@users.sourceforge.net>
 [A] (Alec Muffett <alecm@crypto.dircon.co.uk>)

--- a/package/security/crypto++/crypto++.desc
+++ b/package/security/crypto++/crypto++.desc
@@ -11,7 +11,7 @@
 [T] public key cryptography (including elliptic curves), compression, and
 [T] an easy-to-use filter interface.
 
-[U] https://www.cryptopp.com/
+[U] https://github.com/weidai11/cryptopp
 
 [A] Wei Dai <wdthrowaway@gmail.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/security/cyrus-sasl/cyrus-sasl.desc
+++ b/package/security/cyrus-sasl/cyrus-sasl.desc
@@ -9,7 +9,7 @@
 
 [T] SASL is the Simple Authentication and Security Layer
 
-[U] http://asg.web.cmu.edu/sasl/
+[U] https://www.cyrusimap.org/sasl/
 
 [A] Cyrus staff at CMU
 [M] The T2 Project <t2@t2-project.org>

--- a/package/security/cyrus-sasl2/cyrus-sasl2.desc
+++ b/package/security/cyrus-sasl2/cyrus-sasl2.desc
@@ -9,7 +9,7 @@
 
 [T] SASL is the Simple Authentication and Security Layer
 
-[U] http://asg.web.cmu.edu/sasl/
+[U] https://www.cyrusimap.org/sasl/
 
 [A] Cyrus staff at CMU
 [M] The T2 Project <t2@t2-project.org>

--- a/package/sparc/afbinit/afbinit.desc
+++ b/package/sparc/afbinit/afbinit.desc
@@ -23,4 +23,4 @@
 makeinstopt=
 hook_add postmake 5 "install afbinit $root/sbin/"
 
-[D] 7812656c94cb61567e533520af5665fa34f77ac46f384460902bffb8 afbinit_1.0.orig.tar.gz https://mirror.nju.edu.cn/freebsd-ports/distfiles/afbinit/
+[D] 7812656c94cb61567e533520af5665fa34f77ac46f384460902bffb8 afbinit_1.0.orig.tar.gz https://ftp.up.pt/debian-archive/debian/pool/contrib/a/afbinit/

--- a/package/textproc/celementtree/celementtree.desc
+++ b/package/textproc/celementtree/celementtree.desc
@@ -14,7 +14,7 @@
 [T] range load in zero time (0.0 seconds). This allows you to
 [T] drastically simplify many kinds of XML applications.
 
-[U] http://effbot.org/zone/celementtree.htm
+[U] https://web.archive.org/web/20190707060854/http://effbot.org/zone/celementtree.htm
 
 [A] Fredrik Lundh <fredrik@pythonware.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/themes/blueglass/blueglass.desc
+++ b/package/themes/blueglass/blueglass.desc
@@ -9,7 +9,7 @@
 [T] The same animated cursors as in my 'Golden Xcursors 3D' theme, but this
 [T] time rendered with a bluish, transparent material.
 
-[U] http://www.kde-look.org/content/show.php?content=5532
+[U] https://store.kde.org/p/999915/
 
 [A] ezteban
 [M] The T2 Project <t2@t2-project.org>

--- a/package/themes/crystal-icons-gnome/crystal-icons-gnome.desc
+++ b/package/themes/crystal-icons-gnome/crystal-icons-gnome.desc
@@ -11,7 +11,7 @@
 [T] These are the original Crystal icons re-done in SVG as a base, and
 [T] exported to PNG.
 
-[U] http://www.crystalgnome.org/
+[U] https://web.archive.org/web/20071024115334/http://www.crystalgnome.org/
 
 [A] Exdaix, Chromakode, Panic_69, and Tehmiller
 [M] The T2 Project <t2@t2-project.org>

--- a/package/www/arora/arora.desc
+++ b/package/www/arora/arora.desc
@@ -15,7 +15,7 @@
 [T] layout engine. It features fast rendering, powerful JavaScript engine
 [T] and supports Netscape plugins.
 
-[U] https://code.google.com/p/arora/
+[U] https://github.com/arora/arora
 
 [A] See http://code.google.com/p/arora/people/list
 [M] Roger Mason <rmason@mun.ca>

--- a/package/x11/avant-window-navigator/avant-window-navigator.desc
+++ b/package/x11/avant-window-navigator/avant-window-navigator.desc
@@ -11,8 +11,7 @@
 [T] be used to keep track of open windows and behaves like a normal window
 [T] list.
 
-[U] https://awn-project.org/
-[U] http://wiki.awn-project.org/
+[U] https://launchpad.net/awn/
 
 [A] Neil Jagdish Patel <njpatel@gmail.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/x11/cairo-clock/cairo-clock.desc
+++ b/package/x11/cairo-clock/cairo-clock.desc
@@ -8,7 +8,7 @@
 
 [T] An analog clock displaying the system-time in pretty pixels.
 
-[U] http://macslow.thepimp.net/cairo-clock
+[U] https://launchpad.net/cairo-clock
 
 [A] Mirco "MacSlow" Müller <macslow@gmail.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/x11/compiz/compiz.desc
+++ b/package/x11/compiz/compiz.desc
@@ -10,7 +10,7 @@
 [T] desktop easier to use, more powerful and intuitive, and more accessible
 [T] for users with special needs.
 
-[U] http://www.compiz.org
+[U] https://launchpad.net/compiz
 
 [A] David Reveman <davidr@novell.com>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/x86/cpuburn/cpuburn.desc
+++ b/package/x86/cpuburn/cpuburn.desc
@@ -24,7 +24,7 @@
 [T]
 [T] cpuburn is a shell wrapper for easy use of this applications
 
-[U] http://pages.sbcglobal.net/redelm/
+[U] https://web.archive.org/web/20110623074500/pages.sbcglobal.net/redelm/
 
 [A] Robert Redelmeier <redelm@ev1.net>
 [M] Rene Rebe <rene@t2-project.org>

--- a/package/zope/attachmentfield/attachmentfield.desc
+++ b/package/zope/attachmentfield/attachmentfield.desc
@@ -8,7 +8,7 @@
 
 [T] An Archetypes field managing attachments (with preview and indexing)
 
-[U] http://ingeniweb.sourceforge.net/Products/AttachmentField/
+[U] https://sourceforge.net/projects/ingeniweb/files/
 
 [A] Ingeniweb <support@ingeniweb.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/zope/cmfactionicons/cmfactionicons.desc
+++ b/package/zope/cmfactionicons/cmfactionicons.desc
@@ -18,7 +18,7 @@
 [T] * ZPT macros which build either horizontal or vertical icon bars for a
 [T] set of actions.
 
-[U] https://www.zope.org/Members/tseaver/CMFActionIcons/
+[U] https://github.com/zopefoundation/Products.CMFActionIcons
 
 [A] tseaver <tseaver@zope.com>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/zope/cpssharedcalendar/cpssharedcalendar.desc
+++ b/package/zope/cpssharedcalendar/cpssharedcalendar.desc
@@ -21,7 +21,7 @@
 [T] * meeting helper that looks for free time,
 [T] * etc.
 
-[U] http://www.cps-project.org/sections/projects/calendar_server
+[U] https://web.archive.org/web/20070828034442/https://www.cps-project.org/sections/projects/calendar_server
 
 [A] Nuxeo
 [M] The T2 Project <t2@t2-project.org>

--- a/package/zope/cpsskins/cpsskins.desc
+++ b/package/zope/cpsskins/cpsskins.desc
@@ -9,7 +9,7 @@
 [T] CPSSkins is a visual theme and skins editor for CMF, CPS and Plone.
 [T] It is usefull for Plone skins development.
 
-[U] http://www.medic.chalmers.se/~jmo/CPS/
+[U] https://web.archive.org/web/20080117033845/https://www.medic.chalmers.se/~jmo/CPS/
 
 [A] Jean-Marc Orliaguet <jmo@ita.chalmers.se>
 [M] The T2 Project <t2@t2-project.org>

--- a/package/zope/cssmanager/cssmanager.desc
+++ b/package/zope/cssmanager/cssmanager.desc
@@ -8,7 +8,7 @@
 
 [T] CSSManager is a simple css management tool for Plone 2.
 
-[U] http://opensource.arche.de/products/cssmanager
+[U] https://web.archive.org/web/20061116001051/http://opensource.arche.de/products/cssmanager
 
 [A] Michael Geddert <geddert@arche.de>
 [M] The T2 Project <t2@t2-project.org>


### PR DESCRIPTION
Dead link hunting. Used current sites when available, otherwise fell back to archive.org.
Made progress on a script to help fetch problems and possible replacement URL's from Repology.
However, it doesn't help with packages unique to T2, but was quite helpful for non-unique packages.