### PR TITLE
* kernel: fix hwmon deprecation warnings (Issue #261)

### DIFF
--- a/package/kernel/linux/hwmon-deprecation-fix.patch
+++ b/package/kernel/linux/hwmon-deprecation-fix.patch
@@ -1,0 +1,28 @@
+diff --git a/drivers/hwmon/applesmc.c b/drivers/hwmon/applesmc.c
+index fc6d6a9053ce..01a6dbc66938 100644
+--- a/drivers/hwmon/applesmc.c
++++ b/drivers/hwmon/applesmc.c
+@@ -1362,7 +1362,8 @@ static int __init applesmc_init(void)
+ 	if (ret)
+ 		goto out_light_sysfs;
+ 
+-	hwmon_dev = hwmon_device_register(&pdev->dev);
++	hwmon_dev = hwmon_device_register_with_info(&pdev->dev, "applesmc",
++						    NULL, NULL, NULL);
+ 	if (IS_ERR(hwmon_dev)) {
+ 		ret = PTR_ERR(hwmon_dev);
+ 		goto out_light_ledclass;
+diff --git a/drivers/hwmon/via-cputemp.c b/drivers/hwmon/via-cputemp.c
+index 823bff2871e1..a34950e09281 100644
+--- a/drivers/hwmon/via-cputemp.c
++++ b/drivers/hwmon/via-cputemp.c
+@@ -165,7 +165,8 @@ static int via_cputemp_probe(struct platform_device *pdev)
+ 			goto exit_remove;
+ 	}
+ 
+-	data->hwmon_dev = hwmon_device_register(&pdev->dev);
++	data->hwmon_dev = hwmon_device_register_with_info(&pdev->dev, "via_cputemp",
++							  NULL, NULL, NULL);
+ 	if (IS_ERR(data->hwmon_dev)) {
+ 		err = PTR_ERR(data->hwmon_dev);
+ 		dev_err(&pdev->dev, "Class registration failed (%d)\n",


### PR DESCRIPTION
This PR replaces the deprecated hwmon_device_register() with hwmon_device_register_with_info() in the applesmc and via-cputemp drivers.

Fixes #261