### PR TITLE
develop/flutter: add Flutter SDK package (binary, x86-64)

### DIFF
--- a/package/develop/flutter/flutter.cache
+++ b/package/develop/flutter/flutter.cache
@@ -1,0 +1,3 @@
+[TIMESTAMP] 0
+[BUILDTIME] 0
+[SIZE] 0 MB, 0 files

--- a/package/develop/flutter/flutter.desc
+++ b/package/develop/flutter/flutter.desc
@@ -32,11 +32,20 @@
 
 runmake=0
 prefix=opt/flutter
-set_confopt
 
 flutter_postmake() {
+	install -d $root/$prefix
 	cp -a $builddir/flutter/* $root/$prefix/
-	cd $root/$prefix && git init && git add -A && git commit -m "Flutter $ver"
+
+	# Flutter's CLI requires the SDK directory to be in a git repository.
+	cd $root/$prefix
+	git init
+	git -c user.name="Flutter" -c user.email="flutter@flutter.dev" \
+		add -A
+	git -c user.name="Flutter" -c user.email="flutter@flutter.dev" \
+		commit -m "Flutter $ver"
+
+	install -d $root/usr/bin
 	ln -sf /$prefix/bin/flutter $root/usr/bin/flutter
 }
 


### PR DESCRIPTION
## Summary

  - Adds Flutter SDK 3.38.9 as a binary package under `extra/development`
  - Installs the pre-built Linux SDK to `/opt/flutter`
  - Creates a `/usr/bin/flutter` symlink
  - Adds missing `flutter.cache` file

  ## Details

  Flutter is Google's UI toolkit for building natively compiled applications
  from a single Dart codebase. It is distributed as a pre-built `.tar.xz`
  archive containing the full SDK.

  Flutter's CLI tooling requires the SDK directory to be in a git repository.
  The postmake hook initialises a git repo in the install prefix and commits
  the SDK files so `flutter` commands work out of the box. Git user identity
  is passed inline via `-c user.name/user.email` so the build does not depend
  on a pre-configured `~/.gitconfig` in the build environment.

  ## Test plan

  - [ ] Build on x86-64: `scripts/Build-Pkg flutter`
  - [ ] Verify `/opt/flutter/bin/flutter` is present and executable
  - [ ] Verify `/usr/bin/flutter` symlink is created
  - [ ] Run `flutter doctor` to confirm the SDK is functional
