### PR TITLE
Add more cursor theme packages

### DIFF
--- a/package/themes/bibata-rainbow-cursor/bibata-rainbow-cursor.desc
+++ b/package/themes/bibata-rainbow-cursor/bibata-rainbow-cursor.desc
@@ -1,0 +1,35 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/bibata-rainbow-cursor/bibata-rainbow-cursor.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Semi-animated Bibata cursors with rainbow colors
+
+[T] Bibata Rainbow provides semi-animated variants of the Bibata cursor theme
+[T] with rainbow colors.
+
+[U] https://github.com/ful1e5/Bibata_Cursor_Rainbow
+
+[A] Abdulkaiz Khatri
+[M] The T2 Project <t2@t2-project.org>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 1.1.2
+
+[D] 4d3cd29c65cad62fd1603cc8e37abcdbdef6f436163d49b1afc52a1c Bibata-Rainbow-Modern-1.1.2.tar.gz !https://github.com/ful1e5/Bibata_Cursor_Rainbow/releases/download/v1.1.2/Bibata-Rainbow-Modern.tar.gz
+[D] 8fbd4327e1149fd171532565b790af083fb58d00cdb3976fa6cf7f4f Bibata-Rainbow-Original-1.1.2.tar.gz !https://github.com/ful1e5/Bibata_Cursor_Rainbow/releases/download/v1.1.2/Bibata-Rainbow-Original.tar.gz
+
+autoextract=0
+runmake=0
+install_bibata_rainbow_cursor() {
+	for theme in `match_source_file -p Bibata-Rainbow`; do
+		tar $taropt $theme
+	done
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv Bibata-Rainbow-* $root$(pkgprefix datadir libx11)/icons/
+}
+hook_add postmake 5 install_bibata_rainbow_cursor

--- a/package/themes/bibata-rainbow-cursor/bibata-rainbow-cursor.desc
+++ b/package/themes/bibata-rainbow-cursor/bibata-rainbow-cursor.desc
@@ -12,7 +12,7 @@
 [U] https://github.com/ful1e5/Bibata_Cursor_Rainbow
 
 [A] Abdulkaiz Khatri
-[M] The T2 Project <t2@t2-project.org>
+[M] gl11tchy
 
 [C] extra/theme
 [F] CROSS

--- a/package/themes/capitaine-cursors/capitaine-cursors.desc
+++ b/package/themes/capitaine-cursors/capitaine-cursors.desc
@@ -12,7 +12,7 @@
 [U] https://github.com/keeferrourke/capitaine-cursors
 
 [A] Keefer Rourke <mail@krourke.org>
-[M] The T2 Project <t2@t2-project.org>
+[M] gl11tchy
 
 [C] extra/theme
 [F] CROSS

--- a/package/themes/capitaine-cursors/capitaine-cursors.desc
+++ b/package/themes/capitaine-cursors/capitaine-cursors.desc
@@ -1,0 +1,33 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/capitaine-cursors/capitaine-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] macOS inspired X cursor theme based on KDE Breeze
+
+[T] Capitaine Cursors is an X cursor theme inspired by macOS and based on the
+[T] KDE Breeze cursor artwork.
+
+[U] https://github.com/keeferrourke/capitaine-cursors
+
+[A] Keefer Rourke <mail@krourke.org>
+[M] The T2 Project <t2@t2-project.org>
+
+[C] extra/theme
+[F] CROSS
+
+[L] LGPL3
+[V] 4
+
+[D] 6a283d1b9d2102fca8f3da7dfc7f41472663fb5810eb67c85061e259 capitaine-cursors-4.tar.gz https://github.com/keeferrourke/capitaine-cursors/archive/r4/
+
+runmake=0
+install_capitaine_cursors() {
+	./build.sh -p unix -t dark -d tv
+	./build.sh -p unix -t light -d tv
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv dist/dark $root$(pkgprefix datadir libx11)/icons/capitaine-cursors
+	cp -rfv dist/light $root$(pkgprefix datadir libx11)/icons/capitaine-cursors-white
+}
+hook_add postmake 5 install_capitaine_cursors

--- a/package/themes/layan-cursors/layan-cursors.desc
+++ b/package/themes/layan-cursors/layan-cursors.desc
@@ -12,7 +12,7 @@
 [U] https://github.com/vinceliuice/Layan-cursors
 
 [A] Vince Liuice
-[M] The T2 Project <t2@t2-project.org>
+[M] gl11tchy
 
 [C] extra/theme
 [F] CROSS

--- a/package/themes/layan-cursors/layan-cursors.desc
+++ b/package/themes/layan-cursors/layan-cursors.desc
@@ -1,0 +1,29 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/layan-cursors/layan-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Cursor theme inspired by the Layan GTK theme
+
+[T] Layan Cursors is an X cursor theme inspired by the Layan GTK theme and
+[T] based on Capitaine cursors.
+
+[U] https://github.com/vinceliuice/Layan-cursors
+
+[A] Vince Liuice
+[M] The T2 Project <t2@t2-project.org>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 2021.08.01
+
+[D] 2e6401b564d6b7056cb7026869537dc1a8f95f48c6d03e932a1c3adf Layan-cursors-2021.08.01.tar.gz https://github.com/vinceliuice/Layan-cursors/archive/2021-08-01/
+
+runmake=0
+hook_add postmake 5 "mkdir -p $root$(pkgprefix datadir libx11)/icons/"
+hook_add postmake 5 "cp -rfv dist $root$(pkgprefix datadir libx11)/icons/Layan-cursors"
+hook_add postmake 5 "cp -rfv dist-border $root$(pkgprefix datadir libx11)/icons/Layan-border-cursors"
+hook_add postmake 5 "cp -rfv dist-white $root$(pkgprefix datadir libx11)/icons/Layan-white-cursors"

--- a/package/themes/material-cursors/material-cursors.desc
+++ b/package/themes/material-cursors/material-cursors.desc
@@ -12,7 +12,7 @@
 [U] https://github.com/varlesh/material-cursors
 
 [A] Sergei Eremenko
-[M] The T2 Project <t2@t2-project.org>
+[M] gl11tchy
 
 [C] extra/theme
 [F] CROSS

--- a/package/themes/material-cursors/material-cursors.desc
+++ b/package/themes/material-cursors/material-cursors.desc
@@ -1,0 +1,31 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/material-cursors/material-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Material Design cursor themes
+
+[T] Material Cursors provides Material Design inspired cursor themes in
+[T] multiple colors and sizes.
+
+[U] https://github.com/varlesh/material-cursors
+
+[A] Sergei Eremenko
+[M] The T2 Project <t2@t2-project.org>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL
+[V] 2022.08.17
+
+[D] e1e2c904c63453316840a3f45a200b7cfb8a9260d911baf46320aa06 material-cursors-2022.08.17.tar.gz https://github.com/varlesh/material-cursors/archive/2a5f302fefe04678c421473bed636b4d87774b4a/
+
+runmake=0
+install_material_cursors() {
+	./build.sh
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv dist/* $root$(pkgprefix datadir libx11)/icons/
+}
+hook_add postmake 5 install_material_cursors

--- a/package/themes/mcmojave-cursors/mcmojave-cursors.desc
+++ b/package/themes/mcmojave-cursors/mcmojave-cursors.desc
@@ -12,7 +12,7 @@
 [U] https://github.com/vinceliuice/McMojave-cursors
 
 [A] Vince Liuice
-[M] The T2 Project <t2@t2-project.org>
+[M] gl11tchy
 
 [C] extra/theme
 [F] CROSS

--- a/package/themes/mcmojave-cursors/mcmojave-cursors.desc
+++ b/package/themes/mcmojave-cursors/mcmojave-cursors.desc
@@ -1,0 +1,27 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/mcmojave-cursors/mcmojave-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] macOS inspired cursor theme
+
+[T] McMojave Cursors is an X cursor theme inspired by macOS and based on
+[T] Capitaine cursors.
+
+[U] https://github.com/vinceliuice/McMojave-cursors
+
+[A] Vince Liuice
+[M] The T2 Project <t2@t2-project.org>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 2021.02.24
+
+[D] ff49678b3d1a2d662b6a8a0e0068fbf043e85ccf18da66a4833d3b31 McMojave-cursors-2021.02.24.tar.gz https://github.com/vinceliuice/McMojave-cursors/archive/7d0bfc1f91028191cdc220b87fd335a235ee4439/
+
+runmake=0
+hook_add postmake 5 "mkdir -p $root$(pkgprefix datadir libx11)/icons/"
+hook_add postmake 5 "cp -rfv dist $root$(pkgprefix datadir libx11)/icons/McMojave-cursors"

--- a/package/themes/miniature-cursors/miniature-cursors.desc
+++ b/package/themes/miniature-cursors/miniature-cursors.desc
@@ -1,0 +1,26 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/miniature-cursors/miniature-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] A tiny X11 cursor theme
+
+[T] Miniature is a tiny X11 cursor theme ported from a Windows cursor theme.
+
+[U] https://github.com/nxll/miniature
+
+[A] nxll
+[M] The T2 Project <t2@t2-project.org>
+
+[C] extra/theme
+[F] CROSS
+
+[L] Unknown
+[V] 2017.01.12
+
+[D] 0caaec925803722aeab5d1eec814306816e38f253d64ed37e5070d3f miniature-cursors-2017.01.12.tar.gz https://github.com/nxll/miniature/archive/4a82f88b5dd176df1f14e89444c3edc166d97967/
+
+runmake=0
+hook_add postmake 5 "mkdir -p $root$(pkgprefix datadir libx11)/icons/"
+hook_add postmake 5 "cp -rfv miniature $root$(pkgprefix datadir libx11)/icons/"

--- a/package/themes/miniature-cursors/miniature-cursors.desc
+++ b/package/themes/miniature-cursors/miniature-cursors.desc
@@ -11,7 +11,7 @@
 [U] https://github.com/nxll/miniature
 
 [A] nxll
-[M] The T2 Project <t2@t2-project.org>
+[M] gl11tchy
 
 [C] extra/theme
 [F] CROSS

--- a/package/themes/oreo-cursors/oreo-cursors.desc
+++ b/package/themes/oreo-cursors/oreo-cursors.desc
@@ -1,0 +1,33 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/oreo-cursors/oreo-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Colorful Material Design cursor themes
+
+[T] Oreo Cursors provides colorful Material Design cursor themes with animated
+[T] cursors and configurable color variants.
+
+[U] https://github.com/varlesh/oreo-cursors
+
+[A] Sourav Goswami
+[A] Sergei Eremenko
+[M] The T2 Project <t2@t2-project.org>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL
+[V] 2025.04.19
+
+[D] d3e5d55050611fa64d9b22a5a948a14572878097cc92b37d850787e1 oreo-cursors-2025.04.19.tar.gz https://github.com/varlesh/oreo-cursors/archive/7483f2dec06ae0fce182f9e9fe96c7db23b312b5/
+
+runmake=0
+install_oreo_cursors() {
+	ruby generator/convert.rb
+	./build.sh
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv dist/* $root$(pkgprefix datadir libx11)/icons/
+}
+hook_add postmake 5 install_oreo_cursors

--- a/package/themes/oreo-cursors/oreo-cursors.desc
+++ b/package/themes/oreo-cursors/oreo-cursors.desc
@@ -13,7 +13,7 @@
 
 [A] Sourav Goswami
 [A] Sergei Eremenko
-[M] The T2 Project <t2@t2-project.org>
+[M] gl11tchy
 
 [C] extra/theme
 [F] CROSS


### PR DESCRIPTION
Adds the remaining cursor themes from #223 that were not covered by the earlier partial cursor-theme pass:

- Bibata Rainbow
- Capitaine Cursors
- Layan Cursors
- Material Cursors
- McMojave Cursors
- Miniature Cursors
- Oreo Cursors

The prebuilt cursor archives are installed directly where upstream ships ready-to-use theme directories; themes that only ship source get postmake hooks to generate and install their cursor directories.

Validation:
- scripts/Check-PkgFormat bibata-rainbow-cursor capitaine-cursors layan-cursors material-cursors mcmojave-cursors miniature-cursors oreo-cursors
- verified all [D] source URLs download and match the listed T2 checksums

Fixes #223