### PR TITLE
Enable fat LTO objects for GCC LTO builds

### DIFF
--- a/package/develop/gcc/parse-config
+++ b/package/develop/gcc/parse-config
@@ -238,7 +238,7 @@ else
 	else
 	    var_append GCC_WRAPPER_INSERT ' ' "conftest*.*?:-flto=${SDECFG_PARALLEL:-auto}"
 	    var_append GCC_WRAPPER_INSERT ' ' "conftest*.*?:-shared?:-fwhole-program"
-	    hasflag FAT-LTO && var_append GCC_WRAPPER_INSERT ' ' -ffat-lto-objects
+	    var_append GCC_WRAPPER_INSERT ' ' -ffat-lto-objects
 	fi
     fi
 fi


### PR DESCRIPTION
Fixes #233.\n\nWhen T2 enables GCC LTO globally, the wrapper currently injects -flto but only emits fat LTO objects for packages explicitly marked FAT-LTO. That leaves static archives as slim LTO-only objects, which makes them fragile when linked without the matching GCC LTO plugin or after compiler version changes.\n\nThis makes GCC LTO builds add -ffat-lto-objects by default, so static .a archives retain native object code while still allowing LTO where the toolchain can use it.\n\nVerification:\n- git diff --check\n\nCaveat: this Windows checkout does not have bash available, so bash -n was not runnable here.