### PR TITLE
Add fwupd init script

### DIFF
--- a/package/firmware/fwupd/fwupd.cache
+++ b/package/firmware/fwupd/fwupd.cache
@@ -9,6 +9,7 @@
 [DEP] cmocka
 [DEP] coreutils
 [DEP] curl
+[DEP] dbus
 [DEP] diffutils
 [DEP] findutils
 [OPT] flashrom

--- a/package/firmware/fwupd/fwupd.desc
+++ b/package/firmware/fwupd/fwupd.desc
@@ -16,6 +16,7 @@
 [C] base/tool
 [F] CROSS
 
+[E] add dbus
 [E] add vala
 [E] opt flashrom
 [E] opt gi-docscan graphviz

--- a/package/firmware/fwupd/fwupd.init
+++ b/package/firmware/fwupd/fwupd.init
@@ -1,0 +1,19 @@
+# --- T2-COPYRIGHT-BEGIN ---
+# t2/package/*/fwupd/fwupd.init
+# Copyright (C) 2026 The T2 SDE Project
+# SPDX-License-Identifier: GPL-2.0
+# --- T2-COPYRIGHT-END ---
+
+# Desc: Firmware update daemon
+# Runlevel: 99
+#
+
+main_begin
+	block_begin(start, `Starting fwupd daemon')
+		D_libexecdir/fwupd/fwupd &
+	block_end
+
+	block_begin(stop, `Stopping fwupd daemon')
+		check(`killall fwupd')
+	block_end
+main_end


### PR DESCRIPTION
## Summary
- add an explicit `dbus` dependency for fwupd and update the package cache
- add a T2 init script that starts `/usr/libexec/fwupd/fwupd` and stops it with `killall fwupd`

## Verification
- `git diff --check`

Fixes #124