### PR TITLE
Add OBS WebRTC dependency packages

### DIFF
--- a/package/develop/plog/plog.desc
+++ b/package/develop/plog/plog.desc
@@ -1,0 +1,25 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/plog/plog.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Portable C++ logging library
+
+[T] Plog is a portable, simple, and extensible C++ logging library.
+
+[U] https://github.com/SergiusTheBest/plog
+
+[A] Plog Authors
+[M] bolasse1234 <99745165+bolasse1234@users.noreply.github.com>
+
+[C] extra/development
+[F] CROSS OBJDIR
+
+[L] MIT
+[V] 1.1.11
+[P] X -----5---9 400.000
+
+[D] f6358f7dfabd4c3c8eaf4c091253b3d0f76f62ad2d8eb448c126432a plog-1.1.11.tar.gz https://github.com/SergiusTheBest/plog/archive/1.1.11/
+
+var_append cmakeopt ' ' '-DPLOG_BUILD_SAMPLES=OFF -DPLOG_BUILD_TESTS=OFF'

--- a/package/multimedia/obs-studio/obs-studio.desc
+++ b/package/multimedia/obs-studio/obs-studio.desc
@@ -18,6 +18,7 @@
 [C] extra/multimedia
 [F] CROSS OBJDIR
 
+[E] opt libdatachannel
 [E] opt speex
 
 [L] LGPL
@@ -37,7 +38,8 @@ var_append GCC_WRAPPER_APPEND ' ' "-I$root$(pkgprefix includedir libxcb)"
 var_append cmakeopt ' ' "-DOBS_VERSION_OVERRIDE=$ver"
 var_append cmakeopt ' ' '-DBUILD_VST=OFF -DENABLE_NEW_MPEGTS_OUTPUT=OFF'
 var_append cmakeopt ' ' '-DENABLE_WEBSOCKET=OFF -DENABLE_BROWSER=OFF -DENABLE_AJA=OFF'
-var_append cmakeopt ' ' '-DENABLE_NVENC=OFF -DENABLE_QSV11=OFF -DENABLE_WEBRTC=OFF'
+var_append cmakeopt ' ' '-DENABLE_NVENC=OFF -DENABLE_QSV11=OFF'
+pkginstalled libdatachannel || var_append cmakeopt ' ' -DENABLE_WEBRTC=OFF
 atstage cross && var_append cmakeopt ' ' -DTHREADS_PTHREAD_ARG=YES
 atstage cross && hook_add postmake 5 "rm -rfv $HOME/.cmake/packages"
 [[ "$arch" = x86* ]] && var_append GCC_WRAPPER_APPEND ' ' -c?:-lmvec

--- a/package/network/libdatachannel/libdatachannel.desc
+++ b/package/network/libdatachannel/libdatachannel.desc
@@ -1,0 +1,35 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/libdatachannel/libdatachannel.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] C/C++ WebRTC network library
+
+[T] Libdatachannel is a C/C++ WebRTC network library featuring Data Channels,
+[T] Media Transport, and WebSockets.
+
+[U] https://github.com/paullouisageneau/libdatachannel
+
+[A] Libdatachannel Authors
+[M] bolasse1234 <99745165+bolasse1234@users.noreply.github.com>
+
+[C] extra/network
+[F] CROSS OBJDIR
+
+[E] add libjuice
+[E] add libsrtp
+[E] add libusrsctp
+[E] add openssl
+[E] add plog
+
+[L] MPL
+[V] 0.24.3
+[P] X -----5---9 400.000
+
+[D] 52c40e6e82b516bfc8348257f3b4a17b126ae8c24c3bab4d45c0b440 libdatachannel-0.24.3.tar.gz https://github.com/paullouisageneau/libdatachannel/archive/v0.24.3/
+
+var_append cmakeopt ' ' '-DNO_EXAMPLES=ON -DNO_TESTS=ON'
+var_append cmakeopt ' ' '-DPREFER_SYSTEM_LIB=ON -DUSE_SYSTEM_SRTP=ON'
+var_append cmakeopt ' ' '-DUSE_SYSTEM_JUICE=ON -DUSE_SYSTEM_USRSCTP=ON'
+var_append cmakeopt ' ' '-DUSE_SYSTEM_PLOG=ON'

--- a/package/network/libjuice/libjuice.desc
+++ b/package/network/libjuice/libjuice.desc
@@ -1,0 +1,28 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/libjuice/libjuice.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] UDP Interactive Connectivity Establishment library
+
+[T] JUICE is a UDP Interactive Connectivity Establishment library.
+
+[U] https://github.com/paullouisageneau/libjuice
+
+[A] Libjuice Authors
+[M] bolasse1234 <99745165+bolasse1234@users.noreply.github.com>
+
+[C] extra/network
+[F] CROSS OBJDIR
+
+[E] opt nettle
+
+[L] MPL
+[V] 1.7.1
+[P] X -----5---9 400.000
+
+[D] 74e64bc617650495bca943949c0c08503b4cd071aa687d38d14f3361 libjuice-1.7.1.tar.gz https://github.com/paullouisageneau/libjuice/archive/v1.7.1/
+
+var_append cmakeopt ' ' -DNO_TESTS=ON
+pkginstalled nettle && var_append cmakeopt ' ' -DUSE_NETTLE=ON


### PR DESCRIPTION
This is a scoped chunk for #140 rather than a claim that every OBS optional dependency is now covered.

OBS 32 has a WebRTC output plugin gated on `LibDataChannel`. T2 currently disables it unconditionally, so this adds the missing dependency chain that is not already packaged:

- `plog` 1.1.11, header-only logging library used by libdatachannel
- `libjuice` 1.7.1, ICE library used by libdatachannel
- `libdatachannel` 0.24.3, built with system `libsrtp`, `libusrsctp`, `libjuice`, `plog`, and OpenSSL
- `obs-studio` now treats `libdatachannel` as optional and only passes `-DENABLE_WEBRTC=OFF` when it is not installed

Validation I ran:

- `scripts/Check-PkgFormat plog libjuice libdatachannel obs-studio`
- `scripts/Download -check plog libjuice libdatachannel`
- `git diff --check` (only the Windows checkout line-ending warning)

I did not run a full T2 package build from this Windows workspace. I checked the upstream CMake options so the new libdatachannel package uses system dependencies instead of its vendored submodules.