### PR TITLE
Wire Blender optional dependencies

### DIFF
--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -22,8 +22,23 @@
 [F] OBJDIR
 
 [E] add sse2neon
+[E] opt embree
+[E] opt ffmpeg
+[E] opt fftw3
+[E] opt jack2
+[E] opt libharu
+[E] opt libsndfile
+[E] opt libspnav
 [E] opt libwebp
+[E] opt materialx
+[E] opt openal
+[E] opt opencolorio
+[E] opt openpgl
+[E] opt openshadinglanguage
 [E] opt opensubdiv
+[E] opt openvdb
+[E] opt potrace
+[E] opt pulseaudio
 
 [L] GPL
 [V] 5.1.1
@@ -44,6 +59,20 @@ var_append cmakeopt ' ' "-DWITH_INSTALL_PORTABLE=OFF -DWITH_LIBS_PRECOMPILED=OFF
 var_append cmakeopt ' ' "-DEpoxy_INCLUDE_DIR=$(pkgprefix includedir epoxy)"
 
 pkginstalled tbb || var_append cmakeopt ' ' -DWITH_TBB=OFF
+pkginstalled ffmpeg || var_append cmakeopt ' ' -DWITH_CODEC_FFMPEG=OFF
+pkginstalled fftw3 || var_append cmakeopt ' ' -DWITH_FFTW3=OFF
+pkginstalled jack2 || var_append cmakeopt ' ' -DWITH_JACK=OFF
+pkginstalled libharu || var_append cmakeopt ' ' -DWITH_HARU=OFF
+pkginstalled libsndfile || var_append cmakeopt ' ' -DWITH_CODEC_SNDFILE=OFF
+pkginstalled libspnav || var_append cmakeopt ' ' -DWITH_INPUT_NDOF=OFF
+pkginstalled materialx || var_append cmakeopt ' ' -DWITH_MATERIALX=OFF
+pkginstalled openal || var_append cmakeopt ' ' -DWITH_OPENAL=OFF
+pkginstalled opencolorio || var_append cmakeopt ' ' -DWITH_OPENCOLORIO=OFF
+pkginstalled openpgl || var_append cmakeopt ' ' -DWITH_CYCLES_PATH_GUIDING=OFF
+pkginstalled openshadinglanguage || var_append cmakeopt ' ' -DWITH_CYCLES_OSL=OFF
+pkginstalled openvdb || var_append cmakeopt ' ' -DWITH_OPENVDB=OFF
+pkginstalled potrace || var_append cmakeopt ' ' -DWITH_POTRACE=OFF
+pkginstalled pulseaudio || var_append cmakeopt ' ' -DWITH_PULSEAUDIO=OFF
 #pkginstalled numpy || var_append cmakeopt ' ' -DWITH_PYTHON_NUMPY=OFF
 
 var_append cmakeopt ' ' -DWITH_PYTHON_INSTALL=OFF


### PR DESCRIPTION
This is a scoped follow-up for #139 rather than a claim that every Blender optional dependency is now covered.

T2 already packages a number of libraries that Blender can use, but `blender.desc` only declared `libwebp` and `opensubdiv` as optional package dependencies. This PR wires the existing optional packages into the Blender descriptor and disables the corresponding Blender CMake feature when an optional package is not selected.

Added optional dependency metadata / feature gates for:

- Cycles/rendering: `embree`, `openshadinglanguage`, `openpgl`
- Geometry/import/export/color: `openvdb`, `opencolorio`, `materialx`, `libharu`, `potrace`, `libspnav`
- Audio/media: `ffmpeg`, `fftw3`, `openal`, `libsndfile`, `jack2`, `pulseaudio`

Validation I ran:

- `scripts/Check-PkgFormat blender`
- checked every newly referenced package name resolves to an existing T2 package descriptor
- `git diff --check` (only the Windows checkout line-ending warning)

I did not run a full Blender package build from this Windows workspace. I checked Blender 5.1.1's CMake options/find logic and kept this to optional libraries that are already present in T2.