### PR TITLE
Enable fat LTO objects by default

### DIFF
--- a/package/develop/gcc/parse-config
+++ b/package/develop/gcc/parse-config
@@ -233,12 +233,14 @@ else
 	echo 'Link Time Optimization disabled for this package'
 	SDECFG_LTO=0 # hide from pkgs, might be conditionally disabled for $arch or $cc
     elif ! hasflag CUSTOM-LTO; then
+	# Keep static archives usable as target objects, not just compiler-specific LTO IR.
 	if [ "$SDECFG_DEFAULT_CC" = clang ]; then
 	    var_append GCC_WRAPPER_INSERT ' ' "conftest*.*?:-flto=thin"
+	    var_append GCC_WRAPPER_INSERT ' ' -ffat-lto-objects
 	else
 	    var_append GCC_WRAPPER_INSERT ' ' "conftest*.*?:-flto=${SDECFG_PARALLEL:-auto}"
 	    var_append GCC_WRAPPER_INSERT ' ' "conftest*.*?:-shared?:-fwhole-program"
-	    hasflag FAT-LTO && var_append GCC_WRAPPER_INSERT ' ' -ffat-lto-objects
+	    var_append GCC_WRAPPER_INSERT ' ' -ffat-lto-objects
 	fi
     fi
 fi


### PR DESCRIPTION
Fixes #233.

This makes the default LTO wrapper path add `-ffat-lto-objects` for both GCC and Clang builds when LTO is enabled and the package has not opted into `CUSTOM-LTO` or `NO-LTO`.

The intent is to keep static archives usable as normal target objects instead of only carrying compiler-version-specific LTO IR. GCC already had a `FAT-LTO` escape hatch for selected packages; this turns that into the default behavior for the generic LTO path, including the Clang/ThinLTO path supported by current LLVM.

Validation:
- `git diff --check` passes

I could not run a T2 package/toolchain build from this Windows host because there is no local `bash`, `cc`, `gcc`, or `clang` available here.