### PR TITLE
Add Vimix, WhiteSur and Catppuccin cursor themes

### DIFF
--- a/package/themes/catppuccin-mocha-mauve-cursors/catppuccin-mocha-mauve-cursors.cache
+++ b/package/themes/catppuccin-mocha-mauve-cursors/catppuccin-mocha-mauve-cursors.cache
@@ -1,0 +1,12 @@
+[TIMESTAMP] 1779024476 Sun May 17 21:27:56 2026
+[BUILDTIME] 1 (9)
+[SIZE] 12.00 MB, 164 files
+
+[DEP] bash
+[DEP] coreutils
+[DEP] diffutils
+[DEP] gawk
+[DEP] grep
+[DEP] sed
+[DEP] unzip
+[DEP] xcursor-themes

--- a/package/themes/catppuccin-mocha-mauve-cursors/catppuccin-mocha-mauve-cursors.desc
+++ b/package/themes/catppuccin-mocha-mauve-cursors/catppuccin-mocha-mauve-cursors.desc
@@ -1,0 +1,33 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/catppuccin-mocha-mauve-cursors/catppuccin-mocha-mauve-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Catppuccin Mocha Mauve cursor theme
+
+[T] Catppuccin Cursors is a soothing pastel cursor theme based on Volantes.
+[T] This package installs the Mocha Mauve variant for Xcursor and Hyprcursor.
+
+[U] https://github.com/catppuccin/cursors
+
+[A] Catppuccin Org
+[M] LpcPaul <LpcPaul@users.noreply.github.com>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL
+[V] 2.0.0
+
+[D] 971e113a49de65529b3b706ce8529c1c80f22b2828b9c2f4732b3363fb69fcbb catppuccin-mocha-mauve-cursors-2.0.0.zip !https://github.com/catppuccin/cursors/releases/download/v2.0.0/catppuccin-mocha-mauve-cursors.zip
+
+srcdir=catppuccin-mocha-mauve-cursors chownsrcdir=0 nocvsinsrcdir=0
+runmake=0
+
+install_catppuccin_mocha_mauve_cursors() {
+	mkdir -p $root$datadir/icons/catppuccin-mocha-mauve-cursors
+	cp -rfv AUTHORS LICENSE cursors cursors_scalable hyprcursors index.theme manifest.hl \
+		$root$datadir/icons/catppuccin-mocha-mauve-cursors/
+}
+hook_add postmake 5 install_catppuccin_mocha_mauve_cursors

--- a/package/themes/vimix-cursors/vimix-cursors.cache
+++ b/package/themes/vimix-cursors/vimix-cursors.cache
@@ -1,0 +1,13 @@
+[TIMESTAMP] 1779024476 Sun May 17 21:27:56 2026
+[BUILDTIME] 1 (9)
+[SIZE] 6.40 MB, 164 files
+
+[DEP] bash
+[DEP] coreutils
+[DEP] diffutils
+[DEP] gawk
+[DEP] grep
+[DEP] gzip
+[DEP] sed
+[DEP] tar
+[DEP] xcursor-themes

--- a/package/themes/vimix-cursors/vimix-cursors.desc
+++ b/package/themes/vimix-cursors/vimix-cursors.desc
@@ -1,0 +1,33 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/vimix-cursors/vimix-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Vimix cursor theme for Linux desktops
+
+[T] Vimix Cursors is a rounded cursor theme for Linux desktops, shipping dark
+[T] and white variants.
+
+[U] https://github.com/vinceliuice/Vimix-cursors
+
+[A] Vince Liuice
+[M] LpcPaul <LpcPaul@users.noreply.github.com>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 2020.02.24
+
+[D] 69298d02264b5b15239c340f8fa899f91574c0eac49ad5745e8e588315423618 vimix-cursors-2020-02-24.tar.gz !https://github.com/vinceliuice/Vimix-cursors/archive/refs/tags/2020-02-24.tar.gz
+
+srcdir=Vimix-cursors-2020-02-24 chownsrcdir=0 nocvsinsrcdir=0
+runmake=0
+
+install_vimix_cursors() {
+	mkdir -p $root$datadir/icons
+	cp -rfv dist $root$datadir/icons/Vimix-cursors
+	cp -rfv dist-white $root$datadir/icons/Vimix-white-cursors
+}
+hook_add postmake 5 install_vimix_cursors

--- a/package/themes/whitesur-cursors/whitesur-cursors.cache
+++ b/package/themes/whitesur-cursors/whitesur-cursors.cache
@@ -1,0 +1,13 @@
+[TIMESTAMP] 1779024476 Sun May 17 21:27:56 2026
+[BUILDTIME] 1 (9)
+[SIZE] 4.50 MB, 82 files
+
+[DEP] bash
+[DEP] coreutils
+[DEP] diffutils
+[DEP] gawk
+[DEP] grep
+[DEP] gzip
+[DEP] sed
+[DEP] tar
+[DEP] xcursor-themes

--- a/package/themes/whitesur-cursors/whitesur-cursors.desc
+++ b/package/themes/whitesur-cursors/whitesur-cursors.desc
@@ -1,0 +1,31 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/whitesur-cursors/whitesur-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] WhiteSur cursor theme for Linux desktops
+
+[T] WhiteSur Cursors is a macOS-inspired cursor theme for Linux desktops.
+
+[U] https://github.com/vinceliuice/WhiteSur-cursors
+
+[A] Vince Liuice
+[M] LpcPaul <LpcPaul@users.noreply.github.com>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 2025.04.05
+
+[D] 35c817c2c26bc4d2c06801cfe6c924a068ad771d3846c5203b04d1c893dd5664 whitesur-cursors-2025.04.05.tar.gz !https://github.com/vinceliuice/WhiteSur-cursors/archive/e190baf618ed95ee217d2fd45589bd309b37672b.tar.gz
+
+srcdir=WhiteSur-cursors-e190baf618ed95ee217d2fd45589bd309b37672b chownsrcdir=0 nocvsinsrcdir=0
+runmake=0
+
+install_whitesur_cursors() {
+	mkdir -p $root$datadir/icons
+	cp -rfv dist $root$datadir/icons/WhiteSur-cursors
+}
+hook_add postmake 5 install_whitesur_cursors


### PR DESCRIPTION
Adds three cursor theme packages under package/themes for issue #223:\n\n- vimix-cursors: installs dark and white Vimix Xcursor variants\n- whitesur-cursors: installs the WhiteSur Xcursor theme\n- catppuccin-mocha-mauve-cursors: installs the Catppuccin Mocha Mauve Xcursor and Hyprcursor assets\n\nThe packages use upstream prebuilt cursor directories/assets and add cache metadata with the corresponding archive checksums.\n\nValidation:\n- Downloaded all three upstream archives/assets locally\n- Verified the SHA256 values used in the [D] lines\n- Inspected archive contents for the install paths\n\nNot run:\n- Full T2 package build\n\nBounty/payment details can be provided privately after maintainer review if this qualifies for the cursor-theme bounty.