### PR TITLE
package/themes: add Vimix and Rose Pine cursor themes

### DIFF
--- a/package/themes/catppuccin-cursors/catppuccin-cursors.desc
+++ b/package/themes/catppuccin-cursors/catppuccin-cursors.desc
@@ -1,0 +1,34 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/catppuccin-cursors/catppuccin-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Soothing pastel X cursor themes
+
+[T] Catppuccin Cursors provides X cursor themes using the Catppuccin color
+[T] palette. This package installs the four mauve variants.
+
+[U] https://github.com/catppuccin/cursors
+
+[A] Catppuccin community
+[M] JeremyZeng77 <JeremyZeng77@users.noreply.github.com>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL2
+[V] 2.0.0
+
+[D] a7fc7dc57c7121bd8f1873dbfd5ce35ab317c6b472fcf69681b3a17d2649220e catppuccin-latte-mauve-cursors.zip https://github.com/catppuccin/cursors/releases/download/v2.0.0/
+[D] f901e7e6cdd95ff4d9990373f96208527ef1d9fc8f864004d634c2b8723b1e73 catppuccin-frappe-mauve-cursors.zip https://github.com/catppuccin/cursors/releases/download/v2.0.0/
+[D] e7388debd7694c0da59aaa1d4f37d98517ff9cf231d15b9540e941db3543c1d9 catppuccin-macchiato-mauve-cursors.zip https://github.com/catppuccin/cursors/releases/download/v2.0.0/
+[D] 971e113a49de65529b3b706ce8529c1c80f22b2828b9c2f4732b3363fb69fcbb catppuccin-mocha-mauve-cursors.zip https://github.com/catppuccin/cursors/releases/download/v2.0.0/
+
+srcdir=. chownsrcdir=0 nocvsinsrcdir=0
+runmake=0
+install_catppuccin_cursors() {
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv catppuccin-*-mauve-cursors $root$(pkgprefix datadir libx11)/icons/
+}
+hook_add postmake 5 install_catppuccin_cursors

--- a/package/themes/nordzy-cursors/nordzy-cursors.desc
+++ b/package/themes/nordzy-cursors/nordzy-cursors.desc
@@ -1,0 +1,34 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/nordzy-cursors/nordzy-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Nord inspired X cursor themes
+
+[T] Nordzy Cursors provides X cursor themes inspired by the Nord color
+[T] palette, including dark, white, and left-handed variants.
+
+[U] https://github.com/guillaumeboehm/Nordzy-cursors
+
+[A] Guillaume Boehm
+[M] JeremyZeng77 <JeremyZeng77@users.noreply.github.com>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 2.4.0
+
+[D] 3451c1221d58562a5eb647c45f3f7b5e2bbfe0aacf10d9cbc899bc36e5239e5a Nordzy-cursors.tar.gz https://github.com/guillaumeboehm/Nordzy-cursors/releases/download/v2.4.0/
+[D] 5873641192f7c89692f1335c525969879307482c0f70283142f3fa65cfa74ff6 Nordzy-cursors-white.tar.gz https://github.com/guillaumeboehm/Nordzy-cursors/releases/download/v2.4.0/
+[D] c7edb331809ca5c330a979dc2e67a62c3938c2116968f5519c0cfb452e0a6e8a Nordzy-cursors-lefthand.tar.gz https://github.com/guillaumeboehm/Nordzy-cursors/releases/download/v2.4.0/
+[D] 30e4cb7f35e43ac9ecbfff10266b3326d745e9c30fd5b376c55c958dd4331115 Nordzy-cursors-white-lefthand.tar.gz https://github.com/guillaumeboehm/Nordzy-cursors/releases/download/v2.4.0/
+
+srcdir=. chownsrcdir=0 nocvsinsrcdir=0
+runmake=0
+install_nordzy_cursors() {
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv Nordzy-cursors* $root$(pkgprefix datadir libx11)/icons/
+}
+hook_add postmake 5 install_nordzy_cursors

--- a/package/themes/rose-pine-cursor/rose-pine-cursor.desc
+++ b/package/themes/rose-pine-cursor/rose-pine-cursor.desc
@@ -1,0 +1,33 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/rose-pine-cursor/rose-pine-cursor.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Soho inspired Rose Pine cursor themes
+
+[T] Rose Pine Cursor provides Rose Pine and Rose Pine Dawn X cursor themes
+[T] based on BreezeX Cursor.
+
+[U] https://github.com/rose-pine/cursor
+
+[A] Rose Pine community
+[M] JeremyZeng77 <JeremyZeng77@users.noreply.github.com>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 1.1.0
+
+[D] b330d59ce8e0e460209f638a97ce772b78d9e6b56ccf63c8a50e9d941289a1af BreezeX-RosePine-Linux.tar.xz https://github.com/rose-pine/cursor/releases/download/v1.1.0/
+[D] 85a9dfc31f68a13d536e67200abeb72956300b5388cd3c239b1ce2e198dcadd8 BreezeX-RosePineDawn-Linux.tar.xz https://github.com/rose-pine/cursor/releases/download/v1.1.0/
+
+srcdir=. chownsrcdir=0 nocvsinsrcdir=0
+runmake=0
+install_rose_pine_cursor() {
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv BreezeX-RosePine-Linux $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv BreezeX-RosePineDawn-Linux $root$(pkgprefix datadir libx11)/icons/
+}
+hook_add postmake 5 install_rose_pine_cursor

--- a/package/themes/vimix-cursors/vimix-cursors.desc
+++ b/package/themes/vimix-cursors/vimix-cursors.desc
@@ -1,0 +1,31 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/vimix-cursors/vimix-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Materia inspired X cursor theme
+
+[T] Vimix Cursors is an X cursor theme inspired by Materia design and based on
+[T] Capitaine Cursors.
+
+[U] https://github.com/vinceliuice/Vimix-cursors
+
+[A] Vince Liuice
+[M] JeremyZeng77 <JeremyZeng77@users.noreply.github.com>
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 2020.02.24
+
+[D] 69298d02264b5b15239c340f8fa899f91574c0eac49ad5745e8e588315423618 vimix-cursors-2020.02.24.tar.gz !https://github.com/vinceliuice/Vimix-cursors/archive/refs/tags/2020-02-24.tar.gz
+
+runmake=0
+install_vimix_cursors() {
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv dist $root$(pkgprefix datadir libx11)/icons/Vimix-cursors
+	cp -rfv dist-white $root$(pkgprefix datadir libx11)/icons/Vimix-cursors-white
+}
+hook_add postmake 5 install_vimix_cursors


### PR DESCRIPTION
## Summary
- Add `vimix-cursors` package descriptor for the GPL-3.0 Vimix X cursor themes.
- Add `rose-pine-cursor` package descriptor for the Rose Pine and Rose Pine Dawn Linux cursor theme release assets.
- Add `catppuccin-cursors` package descriptor for the four Catppuccin mauve X cursor variants.
- Add `nordzy-cursors` package descriptor for Nordzy dark, white, and left-handed X cursor variants.
- Install the extracted cursor directories under the X11 icon theme directory, following existing cursor package patterns.

## Bounty / Issue
Related to https://github.com/rxrbln/t2sde/issues/223

## Verification
- Verified SHA256 checksums for all source archives:
  - `vimix-cursors-2020.02.24.tar.gz`: `69298d02264b5b15239c340f8fa899f91574c0eac49ad5745e8e588315423618`
  - `BreezeX-RosePine-Linux.tar.xz`: `b330d59ce8e0e460209f638a97ce772b78d9e6b56ccf63c8a50e9d941289a1af`
  - `BreezeX-RosePineDawn-Linux.tar.xz`: `85a9dfc31f68a13d536e67200abeb72956300b5388cd3c239b1ce2e198dcadd8`
  - `catppuccin-latte-mauve-cursors.zip`: `a7fc7dc57c7121bd8f1873dbfd5ce35ab317c6b472fcf69681b3a17d2649220e`
  - `catppuccin-frappe-mauve-cursors.zip`: `f901e7e6cdd95ff4d9990373f96208527ef1d9fc8f864004d634c2b8723b1e73`
  - `catppuccin-macchiato-mauve-cursors.zip`: `e7388debd7694c0da59aaa1d4f37d98517ff9cf231d15b9540e941db3543c1d9`
  - `catppuccin-mocha-mauve-cursors.zip`: `971e113a49de65529b3b706ce8529c1c80f22b2828b9c2f4732b3363fb69fcbb`
  - `Nordzy-cursors.tar.gz`: `3451c1221d58562a5eb647c45f3f7b5e2bbfe0aacf10d9cbc899bc36e5239e5a`
  - `Nordzy-cursors-white.tar.gz`: `5873641192f7c89692f1335c525969879307482c0f70283142f3fa65cfa74ff6`
  - `Nordzy-cursors-lefthand.tar.gz`: `c7edb331809ca5c330a979dc2e67a62c3938c2116968f5519c0cfb452e0a6e8a`
  - `Nordzy-cursors-white-lefthand.tar.gz`: `30e4cb7f35e43ac9ecbfff10266b3326d745e9c30fd5b376c55c958dd4331115`
- Extracted each archive and verified expected cursor files such as `cursors/left_ptr` are present.
- Simulated the package install copy into a temporary `usr/share/icons` tree.
- `git diff --check` passed.

Payment if this qualifies for the bounty: PayPal https://paypal.me/Jeremytsangchina