### PR TITLE
Package websocketpp for OBS websocket support

### DIFF
--- a/package/develop/qrcodegencpp/qrcodegencpp.desc
+++ b/package/develop/qrcodegencpp/qrcodegencpp.desc
@@ -1,0 +1,35 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/qrcodegencpp/qrcodegencpp.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] QR Code generator library for C++
+
+[T] QR Code generator library is a compact C++ implementation for creating
+[T] QR Code symbols.
+
+[U] https://www.nayuki.io/page/qr-code-generator-library
+
+[A] Project Nayuki
+[M] JeremyZeng77 <JeremyZeng77@users.noreply.github.com>
+
+[C] extra/development
+[F] CROSS
+
+[L] MIT
+[V] 1.8.0
+[P] X -----5---9 400.000
+
+[D] 2ec0a4d33d6f521c942eeaf473d42d5fe139abcfa57d2beffe10c5cf7d34ae60 qrcodegencpp-1.8.0.tar.gz https://github.com/nayuki/QR-Code-generator/archive/refs/tags/v1.8.0/
+
+srcdir=QR-Code-generator-$ver/cpp
+makeopt=libqrcodegencpp.a
+makeinstopt=
+
+install_qrcodegencpp() {
+	mkdir -p $root$includedir $root$libdir
+	cp -v qrcodegen.hpp $root$includedir/
+	cp -v libqrcodegencpp.a $root$libdir/
+}
+hook_add postmake 5 install_qrcodegencpp

--- a/package/develop/websocketpp/websocketpp.desc
+++ b/package/develop/websocketpp/websocketpp.desc
@@ -1,0 +1,31 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/websocketpp/websocketpp.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] C++ WebSocket protocol library
+
+[T] WebSocket++ is a header-only C++ library that implements RFC6455, the
+[T] WebSocket Protocol.
+
+[U] https://github.com/zaphoyd/websocketpp
+
+[A] Peter Thorson
+[M] JeremyZeng77 <JeremyZeng77@users.noreply.github.com>
+
+[C] extra/development
+[F] CROSS
+
+[L] BSD
+[V] 0.8.2
+[P] X -----5---9 400.000
+
+[D] 6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755 websocketpp-0.8.2.tar.gz https://github.com/zaphoyd/websocketpp/archive/refs/tags/0.8.2/
+
+runmake=0
+install_websocketpp_headers() {
+	mkdir -p $root$includedir
+	cp -rfv websocketpp $root$includedir/
+}
+hook_add postmake 5 install_websocketpp_headers

--- a/package/multimedia/obs-studio/obs-studio.desc
+++ b/package/multimedia/obs-studio/obs-studio.desc
@@ -18,7 +18,7 @@
 [C] extra/multimedia
 [F] CROSS OBJDIR
 
-[E] opt speex
+[E] opt speex asio websocketpp
 
 [L] LGPL
 [V] 32.1.2
@@ -36,7 +36,8 @@ pkginstalled libva && var_append GCC_WRAPPER_APPEND ' ' "-I`pkgprefix includedir
 var_append GCC_WRAPPER_APPEND ' ' "-I$root$(pkgprefix includedir libxcb)"
 var_append cmakeopt ' ' "-DOBS_VERSION_OVERRIDE=$ver"
 var_append cmakeopt ' ' '-DBUILD_VST=OFF -DENABLE_NEW_MPEGTS_OUTPUT=OFF'
-var_append cmakeopt ' ' '-DENABLE_WEBSOCKET=OFF -DENABLE_BROWSER=OFF -DENABLE_AJA=OFF'
+pkginstalled asio && pkginstalled websocketpp || var_append cmakeopt ' ' -DENABLE_WEBSOCKET=OFF
+var_append cmakeopt ' ' '-DENABLE_BROWSER=OFF -DENABLE_AJA=OFF'
 var_append cmakeopt ' ' '-DENABLE_NVENC=OFF -DENABLE_QSV11=OFF -DENABLE_WEBRTC=OFF'
 atstage cross && var_append cmakeopt ' ' -DTHREADS_PTHREAD_ARG=YES
 atstage cross && hook_add postmake 5 "rm -rfv $HOME/.cmake/packages"

--- a/package/multimedia/obs-studio/obs-studio.desc
+++ b/package/multimedia/obs-studio/obs-studio.desc
@@ -18,7 +18,7 @@
 [C] extra/multimedia
 [F] CROSS OBJDIR
 
-[E] opt speex asio websocketpp qrcodegencpp
+[E] opt speex asio websocketpp qrcodegencpp libaac librist libsrt
 
 [L] LGPL
 [V] 32.1.2
@@ -35,8 +35,10 @@ pkginstalled vlc || var_append cmakeopt ' ' -DENABLE_VLC=OFF
 pkginstalled libva && var_append GCC_WRAPPER_APPEND ' ' "-I`pkgprefix includedir libva`"
 var_append GCC_WRAPPER_APPEND ' ' "-I$root$(pkgprefix includedir libxcb)"
 var_append cmakeopt ' ' "-DOBS_VERSION_OVERRIDE=$ver"
-var_append cmakeopt ' ' '-DBUILD_VST=OFF -DENABLE_NEW_MPEGTS_OUTPUT=OFF'
+var_append cmakeopt ' ' -DBUILD_VST=OFF
 pkginstalled asio && pkginstalled websocketpp && pkginstalled qrcodegencpp || var_append cmakeopt ' ' -DENABLE_WEBSOCKET=OFF
+pkginstalled librist && pkginstalled libsrt || var_append cmakeopt ' ' -DENABLE_NEW_MPEGTS_OUTPUT=OFF
+pkginstalled libaac && var_append cmakeopt ' ' -DENABLE_LIBFDK=ON
 var_append cmakeopt ' ' '-DENABLE_BROWSER=OFF -DENABLE_AJA=OFF'
 var_append cmakeopt ' ' '-DENABLE_NVENC=OFF -DENABLE_QSV11=OFF -DENABLE_WEBRTC=OFF'
 atstage cross && var_append cmakeopt ' ' -DTHREADS_PTHREAD_ARG=YES

--- a/package/multimedia/obs-studio/obs-studio.desc
+++ b/package/multimedia/obs-studio/obs-studio.desc
@@ -18,7 +18,7 @@
 [C] extra/multimedia
 [F] CROSS OBJDIR
 
-[E] opt speex asio websocketpp
+[E] opt speex asio websocketpp qrcodegencpp
 
 [L] LGPL
 [V] 32.1.2
@@ -36,7 +36,7 @@ pkginstalled libva && var_append GCC_WRAPPER_APPEND ' ' "-I`pkgprefix includedir
 var_append GCC_WRAPPER_APPEND ' ' "-I$root$(pkgprefix includedir libxcb)"
 var_append cmakeopt ' ' "-DOBS_VERSION_OVERRIDE=$ver"
 var_append cmakeopt ' ' '-DBUILD_VST=OFF -DENABLE_NEW_MPEGTS_OUTPUT=OFF'
-pkginstalled asio && pkginstalled websocketpp || var_append cmakeopt ' ' -DENABLE_WEBSOCKET=OFF
+pkginstalled asio && pkginstalled websocketpp && pkginstalled qrcodegencpp || var_append cmakeopt ' ' -DENABLE_WEBSOCKET=OFF
 var_append cmakeopt ' ' '-DENABLE_BROWSER=OFF -DENABLE_AJA=OFF'
 var_append cmakeopt ' ' '-DENABLE_NVENC=OFF -DENABLE_QSV11=OFF -DENABLE_WEBRTC=OFF'
 atstage cross && var_append cmakeopt ' ' -DTHREADS_PTHREAD_ARG=YES


### PR DESCRIPTION
## Summary
- Add a `websocketpp` header-only package descriptor for WebSocket++ 0.8.2.
- Add a `qrcodegencpp` package descriptor for Nayuki QR Code generator C++ 1.8.0.
- Install the upstream WebSocket++ headers and qrcodegen header/static library so OBS can satisfy `FindWebsocketpp.cmake` and `Findqrcodegencpp.cmake`.
- Mark `asio`, `websocketpp`, `qrcodegencpp`, `libaac`, `librist`, and `libsrt` as optional OBS dependencies.
- Keep OBS websocket support enabled only when `asio`, `websocketpp`, and `qrcodegencpp` are installed.
- Keep the new MPEG-TS output enabled only when `librist` and `libsrt` are installed; otherwise disable it to avoid OBS' fatal dependency error.
- Enable OBS FDK AAC support when T2's existing `libaac` package is installed.

## Bounty / Issue
Related to https://github.com/rxrbln/t2sde/issues/140

## Verification
- Downloaded `websocketpp-0.8.2.tar.gz` from the upstream tag and verified SHA256: `6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755`.
- Extracted the WebSocket++ archive and verified `websocketpp/client.hpp` exists.
- Simulated the WebSocket++ header install into a temporary `usr/include/websocketpp` tree.
- Downloaded `qrcodegencpp-1.8.0.tar.gz` from the upstream tag and verified SHA256: `2ec0a4d33d6f521c942eeaf473d42d5fe139abcfa57d2beffe10c5cf7d34ae60`.
- Extracted the QR Code generator archive and verified `cpp/qrcodegen.hpp`, `cpp/qrcodegen.cpp`, and `cpp/Makefile` exist.
- Simulated the qrcodegen header/static-library install paths expected by OBS' finder.
- Cross-checked OBS 32.1.2 `plugins/obs-websocket/CMakeLists.txt`: it requires `qrcodegencpp`, `Websocketpp`, and `Asio` for the websocket plugin and includes `<qrcodegen.hpp>`.
- Cross-checked OBS 32.1.2 `plugins/obs-libfdk/CMakeLists.txt`: `ENABLE_LIBFDK=ON` requires `Libfdk`, which maps to T2's existing `libaac` package.
- Cross-checked OBS 32.1.2 `plugins/obs-ffmpeg/cmake/dependencies.cmake`: new MPEG-TS output requires both `Librist` and `Libsrt`, already packaged in T2.
- `git diff --check` passed.
- Attempted local C++ build verification, but this Windows environment has no `make`, and the installed VS developer environment fails during initialization; I did not count that as a passed build.
- Ran the package-format checker through a CRLF-stripped copy of the script; it reports pre-existing checker limitations for known T2 fields such as `OBJDIR`/`LGPL` and the existing `extra/development` category pattern used by packages like `asio`.

Payment if this qualifies for the bounty: PayPal https://paypal.me/Jeremytsangchina