### PR TITLE
Add Volantes and WhiteSur cursor themes

### DIFF
--- a/package/themes/volantes-cursors/volantes-cursors.cache
+++ b/package/themes/volantes-cursors/volantes-cursors.cache
@@ -1,0 +1,15 @@
+[TIMESTAMP] 1778502400 Mon May 11 14:26:40 2026
+[BUILDTIME] 1 (9)
+[SIZE] 0.01 MB, 230 files
+
+[DEP] bash
+[DEP] coreutils
+[DEP] diffutils
+[DEP] findutils
+[DEP] gawk
+[DEP] grep
+[DEP] gzip
+[DEP] inkscape
+[DEP] sed
+[DEP] tar
+[DEP] xcursorgen

--- a/package/themes/volantes-cursors/volantes-cursors.desc
+++ b/package/themes/volantes-cursors/volantes-cursors.desc
@@ -1,0 +1,30 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/volantes-cursors/volantes-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Cursor theme based on KDE Breeze
+
+[T] Volantes Cursors is an X cursor theme based on KDE Breeze.
+
+[U] https://github.com/varlesh/volantes-cursors
+
+[A] Sergei Eremenko
+[M] gl11tchy
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL
+[V] 2022.10.06
+
+[D] 24a8b82fb99011032669c8721e11ddb05350b57baff7f2b3751853b6868acce1 volantes-cursors-2022.10.06.tar.gz https://github.com/varlesh/volantes-cursors/archive/b13a4bbf6bd1d7e85fadf7f2ecc44acc198f8d01.tar.gz
+
+runmake=0
+install_volantes_cursors() {
+	./build.sh
+	mkdir -p $root$(pkgprefix datadir libx11)/icons/
+	cp -rfv dist/* $root$(pkgprefix datadir libx11)/icons/
+}
+hook_add postmake 5 install_volantes_cursors

--- a/package/themes/whitesur-cursors/whitesur-cursors.cache
+++ b/package/themes/whitesur-cursors/whitesur-cursors.cache
@@ -1,0 +1,13 @@
+[TIMESTAMP] 1778502400 Mon May 11 14:26:40 2026
+[BUILDTIME] 1 (9)
+[SIZE] 0.01 MB, 115 files
+
+[DEP] bash
+[DEP] coreutils
+[DEP] diffutils
+[DEP] findutils
+[DEP] gawk
+[DEP] grep
+[DEP] gzip
+[DEP] sed
+[DEP] tar

--- a/package/themes/whitesur-cursors/whitesur-cursors.desc
+++ b/package/themes/whitesur-cursors/whitesur-cursors.desc
@@ -1,0 +1,27 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/whitesur-cursors/whitesur-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] macOS Big Sur inspired cursor theme
+
+[T] WhiteSur Cursors is an X cursor theme inspired by macOS Big Sur and based
+[T] on Capitaine cursors.
+
+[U] https://github.com/vinceliuice/WhiteSur-cursors
+
+[A] Vince Liuice
+[M] gl11tchy
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 2025.04.05
+
+[D] 35c817c2c26bc4d2c06801cfe6c924a068ad771d3846c5203b04d1c893dd5664 whitesur-cursors-2025.04.05.tar.gz https://github.com/vinceliuice/WhiteSur-cursors/archive/e190baf618ed95ee217d2fd45589bd309b37672b.tar.gz
+
+runmake=0
+hook_add postmake 5 "mkdir -p $root$(pkgprefix datadir libx11)/icons/"
+hook_add postmake 5 "cp -rfv dist $root$(pkgprefix datadir libx11)/icons/WhiteSur-cursors"


### PR DESCRIPTION
Adds two additional open source cursor theme packages for #223:

- volantes-cursors
- whitesur-cursors

Both are maintained cursor themes and install generated/prebuilt cursor theme directories into the X11 icons path, matching the existing cursor theme package style.

Validation:
- Verified source archive SHA256 checksums
- Ran ./scripts/Check-PkgFormat volantes-cursors whitesur-cursors

Fixes #223