### PR TITLE
package/themes: add Retrosmart X11 cursors

### DIFF
--- a/package/themes/retrosmart-x11-cursors/retrosmart-x11-cursors.desc
+++ b/package/themes/retrosmart-x11-cursors/retrosmart-x11-cursors.desc
@@ -1,0 +1,31 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/retrosmart-x11-cursors/retrosmart-x11-cursors.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] Old-fashioned X11 cursor theme
+
+[T] Retrosmart X11 Cursors is a collection of white and black cursor themes
+[T] inspired by old Windows 3.x and OS X cursors.
+
+[U] https://github.com/mdomlop/retrosmart-x11-cursors
+
+[A] Manuel Dominguez Lopez
+[M] gl11tchy
+
+[C] extra/theme
+[F] CROSS
+
+[L] GPL3
+[V] 3.1a
+
+[D] ee3e558868bf581ff328899060a99f8c68ac2d211e4539c0278ec43cf55ddb55 retrosmart-x11-cursors-3.1a.tar.gz https://github.com/mdomlop/retrosmart-x11-cursors/archive/refs/tags/3.1a/
+
+runmake=0
+build_retrosmart_x11_cursors() {
+	make
+	mkdir -p $root$datadir/icons/
+	cp -rfv retrosmart-xcursor-* $root$datadir/icons/
+}
+hook_add postmake 5 build_retrosmart_x11_cursors


### PR DESCRIPTION
﻿## Summary
- add a new `retrosmart-x11-cursors` theme package descriptor
- package the Retrosmart X11 cursor release 3.1a, which provides 8 generated white/black cursor theme variants
- install generated `retrosmart-xcursor-*` icon theme directories under `$datadir/icons`

## Bounty / Issue
Related to https://github.com/rxrbln/t2sde/issues/223

This is intentionally non-overlapping with the currently open cursor-theme PRs for Vimix, Rose Pine, Catppuccin, Nordzy, Volantes, and WhiteSur.

## Verification
- downloaded `https://github.com/mdomlop/retrosmart-x11-cursors/archive/refs/tags/3.1a.tar.gz`
- verified SHA256: `ee3e558868bf581ff328899060a99f8c68ac2d211e4539c0278ec43cf55ddb55`
- inspected the release source and confirmed it builds 8 `retrosmart-xcursor-*` themes from `src/*.theme`
- `git diff --check`

Note: `./scripts/Check-PkgFormat retrosmart-x11-cursors` could not run in this Windows environment because `bash` resolves to WSL and no WSL distro is installed. I validated the required descriptor tags and download hash separately.

Payment if this qualifies for the bounty: PayPal https://paypal.me/onlyyu1996
