### PR TITLE
package/office: add libabw and libvisio system deps

### DIFF
--- a/package/office/libabw/libabw.desc
+++ b/package/office/libabw/libabw.desc
@@ -1,0 +1,28 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/libabw/libabw.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] A library for reading Apple iWork Pages documents
+
+[T] Libabw is a library and a set of tools for reading and converting
+[T] Apple iWork Pages documents.
+
+[U] https://wiki.documentfoundation.org/DLP/Libraries/libabw
+
+[A] Fridrich Strba <fridrich.strba@bluewin.ch>
+[M] JeremyZeng77 <JeremyZeng77@users.noreply.github.com>
+
+[C] extra/office
+[F] CROSS NO-LTO.clang
+
+[E] opt doxygen
+
+[L] MPL
+[V] 0.1.3
+[P] X -----5---9 201.000
+
+[D] 09ee0999a8bcfe00c2484bbf2adff0ee77417f9b9a1c94397ed27472 libabw-0.1.3.tar.xz https://dev-www.libreoffice.org/src/
+
+pkginstalled cppunit || var_append confopt ' ' --disable-tests

--- a/package/office/libreoffice/libreoffice.desc
+++ b/package/office/libreoffice/libreoffice.desc
@@ -27,6 +27,7 @@
 [E] opt pigz
 [E] opt python-lxml
 [E] opt gpgme libgpg-error
+[E] opt libabw libvisio
 [E] add afdko
 [E] opt systemtap
 
@@ -155,6 +156,7 @@ pkginstalled hunspell && var_append confopt ' ' --with-system-hunspell
 pkginstalled icu4c && var_append confopt ' ' --with-system-icu
 pkginstalled lcms2 && var_append confopt ' ' --with-system-lcms2
 pkginstalled libatomic_ops && var_append confopt ' ' --with-system-libatomic_ops
+pkginstalled libabw && var_append confopt ' ' --with-system-libabw
 pkginstalled libcdr && var_append confopt ' ' --with-system-libcdr
 pkginstalled libeot && var_append confopt ' ' --with-system-libeot
 pkginstalled libfixmath && var_append confopt ' ' --with-system-libfixmath
@@ -168,6 +170,7 @@ pkginstalled libpng && var_append confopt ' ' --with-system-libpng
 pkginstalled librevenge && var_append confopt ' ' --with-system-librevenge
 pkginstalled libtiff && var_append confopt ' ' --with-system-libtiff
 pkginstalled libtommath && var_append confopt ' ' --with-system-libtommath
+pkginstalled libvisio && var_append confopt ' ' --with-system-libvisio
 pkginstalled libwebp && var_append confopt ' ' --with-system-libwebp
 pkginstalled libwpd && var_append confopt ' ' --with-system-libwpd
 pkginstalled libxml && var_append confopt ' ' --with-system-libxml

--- a/package/office/libvisio/libvisio.desc
+++ b/package/office/libvisio/libvisio.desc
@@ -1,0 +1,28 @@
+[COPY] --- T2-COPYRIGHT-BEGIN ---
+[COPY] t2/package/*/libvisio/libvisio.desc
+[COPY] Copyright (C) 2026 The T2 SDE Project
+[COPY] SPDX-License-Identifier: GPL-2.0
+[COPY] --- T2-COPYRIGHT-END ---
+
+[I] A library for reading and converting Visio diagrams
+
+[T] Libvisio is a library and a set of tools for reading and converting
+[T] Microsoft Visio diagrams.
+
+[U] https://wiki.documentfoundation.org/DLP/Libraries/libvisio
+
+[A] Fridrich Strba <fridrich.strba@bluewin.ch>
+[M] JeremyZeng77 <JeremyZeng77@users.noreply.github.com>
+
+[C] extra/office
+[F] CROSS NO-LTO.clang
+
+[E] opt doxygen
+
+[L] MPL
+[V] 0.1.10
+[P] X -----5---9 201.000
+
+[D] 1365b3f098eec0c210fb3bb9f97771019c6ea91f1d037a47e0ba8014 libvisio-0.1.10.tar.xz https://dev-www.libreoffice.org/src/
+
+pkginstalled cppunit || var_append confopt ' ' --disable-tests


### PR DESCRIPTION
Related to bounty issue: https://github.com/rxrbln/t2sde/issues/141

## Summary
- add standalone `libabw` and `libvisio` package descriptions using the same LibreOffice DLP source tarballs already referenced by `libreoffice.desc`
- declare them as optional LibreOffice dependencies
- let LibreOffice use `--with-system-libabw` and `--with-system-libvisio` when those packages are installed

## Verification
- `git diff --check`
- downloaded both source tarballs and verified their T2 SHA224 checksums:
  - `libabw-0.1.3.tar.xz` -> `09ee0999a8bcfe00c2484bbf2adff0ee77417f9b9a1c94397ed27472`
  - `libvisio-0.1.10.tar.xz` -> `1365b3f098eec0c210fb3bb9f97771019c6ea91f1d037a47e0ba8014`
- confirmed both tarballs contain autotools build files
- confirmed LibreOffice 26.2.3.2 `configure.ac` contains system-module checks for `libabw` and `libvisio`

## Bounty / payment
Bounty issue: https://github.com/rxrbln/t2sde/issues/141
Preferred payout: PayPal https://paypal.me/Jeremytsangchina
Backup: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`