### PR TITLE
* Update Zig version to 0.17.0-dev.313

### DIFF
--- a/package/zig/zig/zig.desc
+++ b/package/zig/zig/zig.desc
@@ -21,7 +21,7 @@
 [V] 0.17.0-dev.313+27be3b069
 [P] X ?----5---9 109.300
 
-[D] e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 zig-0.17.0-dev.313+27be3b069.tar.xz  https://ziglang.org/builds/
+[D] 6c8970be1121721b01b84b84fad104247306129657b382f3d04478154f9603c3 zig-0.17.0-dev.313+27be3b069.tar.xz  https://ziglang.org/builds/
 
 export ZIG_LOCAL_CACHE_DIR=$builddir/$pkg-$ver/.cache
 export ZIG_GLOBAL_CACHE_DIR=$builddir/$pkg-$ver/.cache

--- a/package/zig/zig/zig.desc
+++ b/package/zig/zig/zig.desc
@@ -18,10 +18,10 @@
 [F] CROSS OBJDIR NO-LTO
 
 [L] MIT
-[V] 0.17.0-dev.251+0db721ec2
+[V] 0.17.0-dev.313+27be3b069
 [P] X ?----5---9 109.300
 
-[D] 4ab051e0e5ef075ffded1084f4f51187408bbc7fba7238b7f7ff189c zig-0.17.0-dev.251+0db721ec2.tar.xz https://ziglang.org/builds/
+[D] e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 zig-0.17.0-dev.313+27be3b069.tar.xz  https://ziglang.org/builds/
 
 export ZIG_LOCAL_CACHE_DIR=$builddir/$pkg-$ver/.cache
 export ZIG_GLOBAL_CACHE_DIR=$builddir/$pkg-$ver/.cache


### PR DESCRIPTION
I have updates ZIG development snapshot to the latest one available. This is `0.17.0-dev.313+27be3b069`. 