### PR TITLE
gcc: emit fat objects for LTO builds

### DIFF
--- a/package/develop/gcc/parse-config
+++ b/package/develop/gcc/parse-config
@@ -238,7 +238,9 @@ else
 	else
 	    var_append GCC_WRAPPER_INSERT ' ' "conftest*.*?:-flto=${SDECFG_PARALLEL:-auto}"
 	    var_append GCC_WRAPPER_INSERT ' ' "conftest*.*?:-shared?:-fwhole-program"
-	    hasflag FAT-LTO && var_append GCC_WRAPPER_INSERT ' ' -ffat-lto-objects
+	    # Keep native code in objects as well as LTO IR so static archives
+	    # remain linkable by non-LTO consumers and after compiler upgrades.
+	    var_append GCC_WRAPPER_INSERT ' ' -ffat-lto-objects
 	fi
     fi
 fi


### PR DESCRIPTION
Fixes #233.

When T2 enables GCC LTO, the wrapper currently injects `-flto` but only adds `-ffat-lto-objects` for packages marked `FAT-LTO`. That leaves static archives made from slim LTO objects dependent on the matching compiler/plugin and can make them fail to link after a compiler major-version change or when consumed by a non-LTO toolchain.

This makes GCC LTO builds emit fat LTO objects by default, preserving native target code alongside the LTO IR so `.a` archives remain usable outside the exact LTO producer setup.

Verification:
- `bash -n package/develop/gcc/parse-config`

Bounty/payment note for #233: PayPal `cultofrozen@gmail.com`.