### PR TITLE
Fix LTO static archives to store native objects

### DIFF
--- a/misc/tools-source/ar_lto_native_wrapper.sh
+++ b/misc/tools-source/ar_lto_native_wrapper.sh
@@ -17,27 +17,31 @@ exec_ar() {
 }
 
 is_lto_object() {
-	file "$1" 2>/dev/null | grep -Eqi 'LLVM.*bitcode|LTO' && return 0
-	readelf -S "$1" 2>/dev/null | grep -q '\.gnu\.lto' && return 0
-	strings "$1" 2>/dev/null | grep -Eq '(^|[_.])gnu_lto|\.gnu\.lto' && return 0
+	file -b "$1" 2>/dev/null | grep -Eqi 'LLVM.*bitcode|LTO' && return 0
+	readelf -S "$1" 2>/dev/null | grep -Eq '\.(gnu|llvm)\.lto' && return 0
+	objdump -h "$1" 2>/dev/null | grep -Eq '\.(gnu|llvm)\.lto' && return 0
 	return 1
 }
 
 native_object_for() {
 	local src="$1" out="$2" cc
 
-	if file "$src" 2>/dev/null | grep -Eqi 'LLVM.*bitcode'; then
+	if file -b "$src" 2>/dev/null | grep -Eqi 'LLVM.*bitcode'; then
 		cc="${CLANG:-${archprefix}clang}"
 		read -r -a cc_argv <<< "${cc:-clang}"
-		"${cc_argv[@]}" -x ir -c -o "$out" "$src"
+		CMD_WRAPPER_BYPASS=1 CC_WRAPPER_BYPASS=1 GCC_WRAPPER_BYPASS=1 \
+			"${cc_argv[@]}" -x ir -c -o "$out" "$src"
 	else
 		cc="${CC:-${archprefix}cc}"
 		read -r -a cc_argv <<< "$cc"
-		"${cc_argv[@]}" -flto -flinker-output=nolto-rel -r -nostdlib -o "$out" "$src"
+		CMD_WRAPPER_BYPASS=1 CC_WRAPPER_BYPASS=1 GCC_WRAPPER_BYPASS=1 \
+			"${cc_argv[@]}" -flto -flinker-output=nolto-rel -r -nostdlib -o "$out" "$src"
 	fi
 
 	if is_lto_object "$out"; then
 		echo "ar_lto_native_wrapper: failed to convert $src to a native object" >&2
+		file "$src" "$out" >&2 || true
+		readelf -S "$out" 2>/dev/null | grep -E '\.(gnu|llvm)\.lto' >&2 || true
 		return 1
 	fi
 }

--- a/misc/tools-source/ar_lto_native_wrapper.sh
+++ b/misc/tools-source/ar_lto_native_wrapper.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# --- T2-COPYRIGHT-BEGIN ---
+# t2/misc/tools-source/ar_lto_native_wrapper.sh
+# Copyright (C) 2026 The T2 SDE Project
+# SPDX-License-Identifier: GPL-2.0
+# --- T2-COPYRIGHT-END ---
+#
+set -e
+
+exec_ar() {
+	local mypath="${CMD_WRAPPER_MYPATH:-$(dirname "$0")}"
+	PATH="${PATH//$mypath:/}"
+	PATH="${PATH//:$mypath/}"
+	export PATH
+	export AR_LTO_NATIVE_WRAPPER_BYPASS=1
+	exec "$(basename "$0")" "$@"
+}
+
+is_lto_object() {
+	file "$1" 2>/dev/null | grep -Eqi 'LLVM.*bitcode|LTO' && return 0
+	readelf -S "$1" 2>/dev/null | grep -q '\.gnu\.lto' && return 0
+	strings "$1" 2>/dev/null | grep -Eq '(^|[_.])gnu_lto|\.gnu\.lto' && return 0
+	return 1
+}
+
+native_object_for() {
+	local src="$1" out="$2" cc
+
+	if file "$src" 2>/dev/null | grep -Eqi 'LLVM.*bitcode'; then
+		cc="${CLANG:-${archprefix}clang}"
+		read -r -a cc_argv <<< "${cc:-clang}"
+		"${cc_argv[@]}" -x ir -c -o "$out" "$src"
+	else
+		cc="${CC:-${archprefix}cc}"
+		read -r -a cc_argv <<< "$cc"
+		"${cc_argv[@]}" -flto -flinker-output=nolto-rel -r -nostdlib -o "$out" "$src"
+	fi
+
+	if is_lto_object "$out"; then
+		echo "ar_lto_native_wrapper: failed to convert $src to a native object" >&2
+		return 1
+	fi
+}
+
+[ "$SDECFG_LTO" = 1 ] && [ "$AR_LTO_NATIVE_WRAPPER_BYPASS" != 1 ] || exec_ar "$@"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+argv=("$@")
+updates= archive=
+for arg in "$@"; do
+	[[ "$arg" = *.a ]] && archive=1
+	[[ "$arg" != --* && "$arg" =~ ^-?[a-zA-Z]*[rq][a-zA-Z]*$ ]] && updates=1
+done
+[ "$updates$archive" = 11 ] || exec_ar "$@"
+
+changed=0
+for i in "${!argv[@]}"; do
+	arg="${argv[$i]}"
+	[ -f "$arg" ] && [[ "$arg" = *.o || "$arg" = *.obj ]] && is_lto_object "$arg" || continue
+	mkdir -p "$tmpdir/$i"
+	out="$tmpdir/$i/$(basename "$arg")"
+	native_object_for "$arg" "$out"
+	argv[$i]="$out"
+	changed=1
+done
+
+[ "$changed" = 1 ] || exec_ar "$@"
+
+exec_ar "${argv[@]}"

--- a/package/develop/gcc/wrappers.in
+++ b/package/develop/gcc/wrappers.in
@@ -21,11 +21,23 @@ gcc_build_wrapper() {
 	done
 }
 
+gcc_build_ar_wrapper() {
+	local y
+	for y; do
+		$y --version > /dev/null 2>&1 || continue
+		wrappers="$wrappers $y"
+		install -m 755 misc/tools-source/ar_lto_native_wrapper.sh \
+			"build/$SDECFG_ID/TOOLCHAIN/$toolsdir/wrapper/$y"
+	done
+}
+
 atstage native ||
 gcc_build_wrapper CPP	CPP ${arch_target}-cpp
 gcc_build_wrapper CC	GCC ${arch_target}-cc ${arch_target}-gcc
 gcc_build_wrapper CXX	GCC ${arch_target}-c++ ${arch_target}-g++
 gcc_build_wrapper KCC	GCC ${arch_target}-kcc
+atstage native ||
+gcc_build_ar_wrapper ${arch_target}-ar ${arch_target}-gcc-ar ${arch_target}-llvm-ar
 
 if atstage native || [ "$SDECFG_USE_CROSSCC" = 0 ]; then
 	gcc_build_wrapper CC  GCC cc gcc
@@ -33,6 +45,7 @@ if atstage native || [ "$SDECFG_USE_CROSSCC" = 0 ]; then
 	gcc_build_wrapper F77 GCC f77 gfortran
 	gcc_build_wrapper KCC GCC kcc
 	gcc_build_wrapper CPP CPP cpp
+	gcc_build_ar_wrapper ar gcc-ar llvm-ar
 else
 	# system compiler used in stage 0 - mostly for ccache
 	gcc_build_wrapper SYSCC  SYSGCC {,g}cc


### PR DESCRIPTION
Fixes #233.

This keeps static archives native-only when global LTO is enabled. Instead of adding fat LTO objects globally, the new ar wrapper only intercepts static `.a` archive updates while `SDECFG_LTO=1`, converts any LTO/LLVM bitcode object members to native object files in a temporary directory, verifies the converted members no longer look like LTO bytecode, and then passes the native objects to the real `ar`.

Non-archive commands, non-update archive commands, non-LTO objects, and builds with `SDECFG_LTO` disabled bypass to the real `ar`.

Verification:
- `bash -n misc/tools-source/ar_lto_native_wrapper.sh`
- `git diff --check`
- GCC `-flto` object archived with `SDECFG_LTO=1`, extracted member is a native Mach-O object and has no `LLVM bitcode`, `LTO`, or `.gnu.lto` markers
- Clang `-flto` object archived with `SDECFG_LTO=1`, extracted member is a native Mach-O object and has no `LLVM bitcode`, `LTO`, or `.gnu.lto` markers
- GCC `-flto` object archived with `SDECFG_LTO=0`, extracted member remains LLVM bitcode as a bypass control
- Duplicate member basenames are preserved when archive inputs come from different directories