### PR TITLE
Add Open Image Denoise for Blender

### DIFF
--- a/package/multimedia/blender/blender.cache
+++ b/package/multimedia/blender/blender.cache
@@ -40,6 +40,7 @@
 [DEP] opencolorio
 [DEP] openexr
 [DEP] openimageio
+[OPT] openimagedenoise
 [DEP] openjpeg
 [DEP] openpgl
 [DEP] openshadinglanguage

--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -23,6 +23,7 @@
 
 [E] add sse2neon
 [E] opt libwebp
+[E] opt openimagedenoise
 [E] opt opensubdiv
 
 [L] GPL
@@ -44,6 +45,7 @@ var_append cmakeopt ' ' "-DWITH_INSTALL_PORTABLE=OFF -DWITH_LIBS_PRECOMPILED=OFF
 var_append cmakeopt ' ' "-DEpoxy_INCLUDE_DIR=$(pkgprefix includedir epoxy)"
 
 pkginstalled tbb || var_append cmakeopt ' ' -DWITH_TBB=OFF
+pkginstalled openimagedenoise || var_append cmakeopt ' ' -DWITH_OPENIMAGEDENOISE=OFF
 #pkginstalled numpy || var_append cmakeopt ' ' -DWITH_PYTHON_NUMPY=OFF
 
 var_append cmakeopt ' ' -DWITH_PYTHON_INSTALL=OFF


### PR DESCRIPTION
Contributes to #139.

This adds an `openimagedenoise` package for Intel Open Image Denoise 2.4.1 and wires Blender to use it as an optional dependency. The package is limited to x86-64 and arm64, uses the upstream source release tarball, depends on existing `ispc` and `tbb`, disables the GPU backends by default, and keeps `OIDN_INSTALL_DEPENDENCIES=OFF` so T2 packages provide dependencies.

Blender now advertises `openimagedenoise` as optional and explicitly configures `-DWITH_OPENIMAGEDENOISE=OFF` when it is not selected.

Validation performed on this Windows host:
- `scripts/Check-PkgFormat openimagedenoise blender`
- `scripts/Download openimagedenoise` fetched and verified the T2 source entry after the mirror 404 fallback to the upstream release URL
- Recomputed the T2-style SHA-224 checksum over the decompressed `oidn-2.4.1.src.tar.gz` stream and matched the descriptor
- Checked the source tarball contains the OIDN headers, CPU CMake files, FindTBB module, and `.tza` weights
- `git diff --check`

Not run: a full T2/Linux package build, because this is a Windows host.

If this is accepted as eligible bounty work, PayPal is: https://www.paypal.com/paypalme/aogkft
