### PR TITLE
Expand Blender optional dependency wiring

### DIFF
--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -22,10 +22,21 @@
 [F] OBJDIR
 
 [E] add sse2neon
+[E] opt embree
+[E] opt fftw3
+[E] opt jack
+[E] opt libharu
 [E] opt libwebp
 [E] opt materialx
-[E] opt openvdb
+[E] opt openal
+[E] opt openjpeg
+[E] opt openpgl
+[E] opt openshadinglanguage
 [E] opt opensubdiv
+[E] opt openvdb
+[E] opt potrace
+[E] opt pugixml
+[E] opt tbb
 
 [L] GPL
 [V] 5.1.2
@@ -45,9 +56,19 @@ fi
 var_append cmakeopt ' ' "-DWITH_INSTALL_PORTABLE=OFF -DWITH_LIBS_PRECOMPILED=OFF"
 var_append cmakeopt ' ' "-DEpoxy_INCLUDE_DIR=$(pkgprefix includedir epoxy)"
 
+pkginstalled fftw3 || var_append cmakeopt ' ' -DWITH_FFTW3=OFF
+pkginstalled jack || var_append cmakeopt ' ' -DWITH_JACK=OFF
+pkginstalled libharu || var_append cmakeopt ' ' -DWITH_HARU=OFF
 pkginstalled tbb || var_append cmakeopt ' ' -DWITH_TBB=OFF
+pkginstalled openal || var_append cmakeopt ' ' -DWITH_OPENAL=OFF
+pkginstalled openjpeg || var_append cmakeopt ' ' -DWITH_IMAGE_OPENJPEG=OFF
+pkginstalled openpgl || var_append cmakeopt ' ' -DWITH_CYCLES_PATH_GUIDING=OFF
+pkginstalled openshadinglanguage || var_append cmakeopt ' ' -DWITH_CYCLES_OSL=OFF
+pkginstalled opensubdiv || var_append cmakeopt ' ' -DWITH_OPENSUBDIV=OFF
 pkginstalled materialx || var_append cmakeopt ' ' -DWITH_MATERIALX=OFF
 pkginstalled openvdb || var_append cmakeopt ' ' -DWITH_OPENVDB=OFF
+pkginstalled potrace || var_append cmakeopt ' ' -DWITH_POTRACE=OFF
+pkginstalled pugixml || var_append cmakeopt ' ' -DWITH_PUGIXML=OFF
 #pkginstalled numpy || var_append cmakeopt ' ' -DWITH_PYTHON_NUMPY=OFF
 
 var_append cmakeopt ' ' -DWITH_PYTHON_INSTALL=OFF

--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -26,9 +26,11 @@
 [E] opt fftw3
 [E] opt jack
 [E] opt libharu
+[E] opt libsndfile
 [E] opt libwebp
 [E] opt materialx
 [E] opt openal
+[E] opt opencolorio
 [E] opt openjpeg
 [E] opt openpgl
 [E] opt openshadinglanguage
@@ -36,6 +38,8 @@
 [E] opt openvdb
 [E] opt potrace
 [E] opt pugixml
+[E] opt pulseaudio
+[E] opt rubberband
 [E] opt tbb
 
 [L] GPL
@@ -59,8 +63,11 @@ var_append cmakeopt ' ' "-DEpoxy_INCLUDE_DIR=$(pkgprefix includedir epoxy)"
 pkginstalled fftw3 || var_append cmakeopt ' ' -DWITH_FFTW3=OFF
 pkginstalled jack || var_append cmakeopt ' ' -DWITH_JACK=OFF
 pkginstalled libharu || var_append cmakeopt ' ' -DWITH_HARU=OFF
+pkginstalled libsndfile || var_append cmakeopt ' ' -DWITH_CODEC_SNDFILE=OFF
+pkginstalled libwebp || var_append cmakeopt ' ' -DWITH_IMAGE_WEBP=OFF
 pkginstalled tbb || var_append cmakeopt ' ' -DWITH_TBB=OFF
 pkginstalled openal || var_append cmakeopt ' ' -DWITH_OPENAL=OFF
+pkginstalled opencolorio || var_append cmakeopt ' ' -DWITH_OPENCOLORIO=OFF
 pkginstalled openjpeg || var_append cmakeopt ' ' -DWITH_IMAGE_OPENJPEG=OFF
 pkginstalled openpgl || var_append cmakeopt ' ' -DWITH_CYCLES_PATH_GUIDING=OFF
 pkginstalled openshadinglanguage || var_append cmakeopt ' ' -DWITH_CYCLES_OSL=OFF
@@ -69,6 +76,8 @@ pkginstalled materialx || var_append cmakeopt ' ' -DWITH_MATERIALX=OFF
 pkginstalled openvdb || var_append cmakeopt ' ' -DWITH_OPENVDB=OFF
 pkginstalled potrace || var_append cmakeopt ' ' -DWITH_POTRACE=OFF
 pkginstalled pugixml || var_append cmakeopt ' ' -DWITH_PUGIXML=OFF
+pkginstalled pulseaudio || var_append cmakeopt ' ' -DWITH_PULSEAUDIO=OFF
+pkginstalled rubberband || var_append cmakeopt ' ' -DWITH_RUBBERBAND=OFF
 #pkginstalled numpy || var_append cmakeopt ' ' -DWITH_PYTHON_NUMPY=OFF
 
 var_append cmakeopt ' ' -DWITH_PYTHON_INSTALL=OFF

--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -45,7 +45,9 @@
 [E] opt pugixml
 [E] opt pulseaudio
 [E] opt rubberband
+[E] opt shaderc
 [E] opt tbb
+[E] opt vulkan-loader
 [E] opt wayland wayland-protocols xkbcommon
 
 [L] GPL
@@ -89,6 +91,7 @@ pkginstalled pugixml || var_append cmakeopt ' ' -DWITH_PUGIXML=OFF
 pkginstalled pipewire || var_append cmakeopt ' ' -DWITH_PIPEWIRE=OFF
 pkginstalled pulseaudio || var_append cmakeopt ' ' -DWITH_PULSEAUDIO=OFF
 pkginstalled rubberband || var_append cmakeopt ' ' -DWITH_RUBBERBAND=OFF
+pkginstalled shaderc vulkan-loader || var_append cmakeopt ' ' -DWITH_VULKAN_BACKEND=OFF
 pkginstalled wayland wayland-protocols xkbcommon || var_append cmakeopt ' ' -DWITH_GHOST_WAYLAND=OFF
 #pkginstalled numpy || var_append cmakeopt ' ' -DWITH_PYTHON_NUMPY=OFF
 

--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -22,6 +22,7 @@
 [F] OBJDIR
 
 [E] add sse2neon
+[E] opt ceres-solver
 [E] opt embree
 [E] opt ffmpeg
 [E] opt fftw3
@@ -68,6 +69,7 @@ fi
 var_append cmakeopt ' ' "-DWITH_INSTALL_PORTABLE=OFF -DWITH_LIBS_PRECOMPILED=OFF"
 var_append cmakeopt ' ' "-DEpoxy_INCLUDE_DIR=$(pkgprefix includedir epoxy)"
 
+pkginstalled ceres-solver || var_append cmakeopt ' ' -DWITH_LIBMV=OFF
 pkginstalled ffmpeg || var_append cmakeopt ' ' -DWITH_CODEC_FFMPEG=OFF
 pkginstalled fftw3 || var_append cmakeopt ' ' -DWITH_FFTW3=OFF
 pkginstalled gmp || var_append cmakeopt ' ' -DWITH_GMP=OFF

--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -24,6 +24,7 @@
 [E] add sse2neon
 [E] opt embree
 [E] opt fftw3
+[E] opt gmp
 [E] opt jack
 [E] opt libharu
 [E] opt libsndfile
@@ -36,11 +37,13 @@
 [E] opt openshadinglanguage
 [E] opt opensubdiv
 [E] opt openvdb
+[E] opt pipewire
 [E] opt potrace
 [E] opt pugixml
 [E] opt pulseaudio
 [E] opt rubberband
 [E] opt tbb
+[E] opt wayland wayland-protocols xkbcommon
 
 [L] GPL
 [V] 5.1.2
@@ -61,6 +64,7 @@ var_append cmakeopt ' ' "-DWITH_INSTALL_PORTABLE=OFF -DWITH_LIBS_PRECOMPILED=OFF
 var_append cmakeopt ' ' "-DEpoxy_INCLUDE_DIR=$(pkgprefix includedir epoxy)"
 
 pkginstalled fftw3 || var_append cmakeopt ' ' -DWITH_FFTW3=OFF
+pkginstalled gmp || var_append cmakeopt ' ' -DWITH_GMP=OFF
 pkginstalled jack || var_append cmakeopt ' ' -DWITH_JACK=OFF
 pkginstalled libharu || var_append cmakeopt ' ' -DWITH_HARU=OFF
 pkginstalled libsndfile || var_append cmakeopt ' ' -DWITH_CODEC_SNDFILE=OFF
@@ -76,8 +80,10 @@ pkginstalled materialx || var_append cmakeopt ' ' -DWITH_MATERIALX=OFF
 pkginstalled openvdb || var_append cmakeopt ' ' -DWITH_OPENVDB=OFF
 pkginstalled potrace || var_append cmakeopt ' ' -DWITH_POTRACE=OFF
 pkginstalled pugixml || var_append cmakeopt ' ' -DWITH_PUGIXML=OFF
+pkginstalled pipewire || var_append cmakeopt ' ' -DWITH_PIPEWIRE=OFF
 pkginstalled pulseaudio || var_append cmakeopt ' ' -DWITH_PULSEAUDIO=OFF
 pkginstalled rubberband || var_append cmakeopt ' ' -DWITH_RUBBERBAND=OFF
+pkginstalled wayland wayland-protocols xkbcommon || var_append cmakeopt ' ' -DWITH_GHOST_WAYLAND=OFF
 #pkginstalled numpy || var_append cmakeopt ' ' -DWITH_PYTHON_NUMPY=OFF
 
 var_append cmakeopt ' ' -DWITH_PYTHON_INSTALL=OFF

--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -23,6 +23,8 @@
 
 [E] add sse2neon
 [E] opt libwebp
+[E] opt materialx
+[E] opt openvdb
 [E] opt opensubdiv
 
 [L] GPL
@@ -44,6 +46,8 @@ var_append cmakeopt ' ' "-DWITH_INSTALL_PORTABLE=OFF -DWITH_LIBS_PRECOMPILED=OFF
 var_append cmakeopt ' ' "-DEpoxy_INCLUDE_DIR=$(pkgprefix includedir epoxy)"
 
 pkginstalled tbb || var_append cmakeopt ' ' -DWITH_TBB=OFF
+pkginstalled materialx || var_append cmakeopt ' ' -DWITH_MATERIALX=OFF
+pkginstalled openvdb || var_append cmakeopt ' ' -DWITH_OPENVDB=OFF
 #pkginstalled numpy || var_append cmakeopt ' ' -DWITH_PYTHON_NUMPY=OFF
 
 var_append cmakeopt ' ' -DWITH_PYTHON_INSTALL=OFF

--- a/package/multimedia/blender/blender.desc
+++ b/package/multimedia/blender/blender.desc
@@ -23,15 +23,18 @@
 
 [E] add sse2neon
 [E] opt embree
+[E] opt ffmpeg
 [E] opt fftw3
 [E] opt gmp
 [E] opt jack
 [E] opt libharu
 [E] opt libsndfile
+[E] opt libspnav
 [E] opt libwebp
 [E] opt materialx
 [E] opt openal
 [E] opt opencolorio
+[E] opt openexr
 [E] opt openjpeg
 [E] opt openpgl
 [E] opt openshadinglanguage
@@ -63,15 +66,18 @@ fi
 var_append cmakeopt ' ' "-DWITH_INSTALL_PORTABLE=OFF -DWITH_LIBS_PRECOMPILED=OFF"
 var_append cmakeopt ' ' "-DEpoxy_INCLUDE_DIR=$(pkgprefix includedir epoxy)"
 
+pkginstalled ffmpeg || var_append cmakeopt ' ' -DWITH_CODEC_FFMPEG=OFF
 pkginstalled fftw3 || var_append cmakeopt ' ' -DWITH_FFTW3=OFF
 pkginstalled gmp || var_append cmakeopt ' ' -DWITH_GMP=OFF
 pkginstalled jack || var_append cmakeopt ' ' -DWITH_JACK=OFF
 pkginstalled libharu || var_append cmakeopt ' ' -DWITH_HARU=OFF
 pkginstalled libsndfile || var_append cmakeopt ' ' -DWITH_CODEC_SNDFILE=OFF
+pkginstalled libspnav || var_append cmakeopt ' ' -DWITH_INPUT_NDOF=OFF
 pkginstalled libwebp || var_append cmakeopt ' ' -DWITH_IMAGE_WEBP=OFF
 pkginstalled tbb || var_append cmakeopt ' ' -DWITH_TBB=OFF
 pkginstalled openal || var_append cmakeopt ' ' -DWITH_OPENAL=OFF
 pkginstalled opencolorio || var_append cmakeopt ' ' -DWITH_OPENCOLORIO=OFF
+pkginstalled openexr || var_append cmakeopt ' ' -DWITH_IMAGE_OPENEXR=OFF
 pkginstalled openjpeg || var_append cmakeopt ' ' -DWITH_IMAGE_OPENJPEG=OFF
 pkginstalled openpgl || var_append cmakeopt ' ' -DWITH_CYCLES_PATH_GUIDING=OFF
 pkginstalled openshadinglanguage || var_append cmakeopt ' ' -DWITH_CYCLES_OSL=OFF


### PR DESCRIPTION
## Summary
- declare additional existing T2 packages as optional Blender dependencies
- disable matching Blender CMake features when those optional packages are absent
- keep the prior MaterialX/OpenVDB optional dependency handling from this PR

Covered optional feature gates now include Ceres/LibMV, Embree/Cycles, FFmpeg, FFTW3, GMP exact booleans, JACK, Libharu, libsndfile, libspnav/NDOF input, libwebp, OpenAL, OpenColorIO, OpenEXR, OpenJPEG, OpenPGL path guiding, OpenShadingLanguage, OpenSubdiv, OpenVDB, PipeWire, Potrace, PugiXML, PulseAudio, Rubberband, TBB, Vulkan backend, Wayland windowing, and MaterialX.

Refs #139

## Verification
- checked Blender 5.1.2 upstream CMake options in `CMakeLists.txt` and Linux dependency lookup in `build_files/cmake/platform/platform_unix.cmake`
- checked official `v5.1.2` tag SHA on `projects.blender.org` and used the matching official GitHub mirror for source-file inspection after the project host returned a raw-file challenge
- checked matching T2 package descriptors for `ceres-solver`, `ffmpeg`, `gmp`, `libspnav`, `openexr`, `pipewire`, `shaderc`, `vulkan-loader`, `wayland`, `wayland-protocols`, `xkbcommon`, `libsndfile`, `libwebp`, `opencolorio`, `pulseaudio`, and `rubberband`
- `scripts/Check-PkgFormat blender`
- `scripts/Check-PkgFormat blender` after the GMP/PipeWire/Wayland follow-up
- `scripts/Check-PkgFormat blender` after the FFmpeg/OpenEXR/libspnav follow-up
- `scripts/Check-PkgFormat blender` after the Vulkan backend follow-up
- `scripts/Check-PkgFormat blender` after the Ceres/LibMV follow-up
- `git diff --check` (passes; Windows host warns that LF will be replaced by CRLF when Git touches the file)

I could not run a full T2 Blender package build from this Windows host.

If this is accepted as eligible bounty work, PayPal is: https://www.paypal.com/paypalme/aogkft




