### PR TITLE
fix rst2html5 and docutils overlap

### DIFF
--- a/package/emulators/libvirt/libvirt.desc
+++ b/package/emulators/libvirt/libvirt.desc
@@ -28,7 +28,7 @@
 [E] opt acl
 [E] opt audit
 [E] opt cyrus-sasl2
-[E] opt docutils rst2html5
+[E] opt docutils
 [E] opt glusterfs
 [E] opt libiscsi
 [E] opt libssh


### PR DESCRIPTION
Fixes #351 

```
grep -R "rst2html5" -n package

package/emulators/libvirt/libvirt.desc:31:[E] opt docutils rst2html5
package/emulators/libvirt/libvirt.cache:46:[OPT] rst2html5
package/python/rst2html5/rst2html5.desc:2:[COPY] t2/package/*/rst2html5/rst2html5.desc
package/python/rst2html5/rst2html5.desc:11:[U] https://foss.heptapod.net/doc-utils/rst2html5/-/tree/branch/default
package/python/rst2html5/rst2html5.desc:23:[D] 500b1abf7b1549c53e9d2be40a01363723f3337c25fd8bb64aa2fba1 rst2html5-2.0.1.tar.gz https://files.pythonhosted.org/packages/source/r/rst2html5/
package/shells/thefuck/thefuck.cache:30:[DEP] rst2html5
```