### PR TITLE
fix POSIX /bin/sh issues

### DIFF
--- a/misc/tools-source/fl_wrapper_test.sh
+++ b/misc/tools-source/fl_wrapper_test.sh
@@ -7,14 +7,14 @@
 # SPDX-License-Identifier: GPL-2.0
 # --- T2-COPYRIGHT-END ---
 
-for x in exec{l,v}{,p,e} ; do
+for x in execl execlp execle execv execvp execve ; do
 touch fltest_$x ; done
 
 bash misc/tools-source/fl_wrapper.c.sh > fl_wrapper.c
 gcc -O2 -shared -fPIC -Wall -ldl fl_wrapper.c -o fl_wrapper.so
 
-echo -n > rlog.txt
-echo -n > wlog.txt
+: > rlog.txt
+: > wlog.txt
 
 export FLWRAPPER_RLOG=rlog.txt
 export FLWRAPPER_WLOG=wlog.txt

--- a/package/emulators/libvirt/libvirt.desc
+++ b/package/emulators/libvirt/libvirt.desc
@@ -28,7 +28,7 @@
 [E] opt acl
 [E] opt audit
 [E] opt cyrus-sasl2
-[E] opt docutils rst2html5
+[E] opt docutils
 [E] opt glusterfs
 [E] opt libiscsi
 [E] opt libssh


### PR DESCRIPTION
Brace expansion is not supported in POSIX. Fixes follow POSIX standards for `/bin/sh`. Avoids bash-specific features that can cause portability issues across different Unix systems.