### PR TITLE
hotfix opencv-python: add scikit-build-core build dependency (#357)

### DIFF
--- a/package/base/readline/hotfix-shlib-destdir.patch
+++ b/package/base/readline/hotfix-shlib-destdir.patch
@@ -1,0 +1,51 @@
+# --- T2-COPYRIGHT-BEGIN ---
+# t2/package/*/readline/hotfix-shlib-destdir.patch
+# Copyright (C) 2026 The T2 SDE Project
+# SPDX-License-Identifier: GPL-2.0 or patched project license
+# --- T2-COPYRIGHT-END ---
+#
+# shlib-install doesn't know about DESTDIR. During cross-compilation T2
+# passes DESTDIR=$root to install to the sysroot, but shlib-install ignores
+# it and writes straight to /usr/lib* on the HOST. This corrupts the host's
+# readline libraries and can break /bin/sh (bash) at runtime.
+#
+# Fix: prepend DESTDIR to all install paths in shlib-install.
+
+--- readline-8.3/support/shlib-install.vanilla	2026-06-06 00:00:00.000000000 +0200
++++ readline-8.3/support/shlib-install	2026-06-06 12:00:00.000000000 +0200
+@@ -1,3 +1,10 @@
++# prepend DESTDIR to all install paths if set
++if [ -n "$DESTDIR" ]; then
++	case "$DESTDIR" in
++		*/)	;;
++		*)	DESTDIR="$DESTDIR/" ;;
++	esac
++fi
++
+ #! /bin/sh
+ #
+ # shlib-install - install a shared library and do any necessary host-specific
+@@ -23,12 +30,12 @@
+ -O)	shift; host_os="$1"; shift ;;
+ -V)	shift; host_vendor="$1"; shift ;;
+ -d)	shift; INSTALLDIR="$1"; shift ;;
+--b)	shift; BINDIR="$1" ; shift ;;
++-b)	shift; BINDIR="${DESTDIR}$1" ; shift ;;
+ -i)	shift; INSTALLPROG="$1" ; shift ;;
+ -D)	echo=echo ; shift ;;
+ -U)	uninstall=true ; shift ;;
+ -*)	echo "$USAGE" >&2 ; exit 2;;
+ *)	break ;;
+ esac
+ done
+ 
+@@ -39,6 +46,9 @@
+ # set install target name
+ LIBNAME="$1"
+ 
++# prepend DESTDIR to the install directory
++INSTALLDIR="${DESTDIR}${INSTALLDIR}"
++
+ if [ -z "$LIBNAME" ]; then
+ 	echo "$USAGE" >&2
+ 	exit 2

--- a/package/develop/gcc/gcc.desc
+++ b/package/develop/gcc/gcc.desc
@@ -321,6 +321,15 @@ if [ "$SDECFG_LIBC" != "glibc" ]; then
 	var_remove languages ',' go
 fi
 
+# libsanitizer needs <crypt.h> which moved from glibc to libxcrypt.
+# Check at build time: if the header isn't in the sysroot, disable it.
+if [ $stagelevel -ge 2 ] && ! pkginstalled libxcrypt; then
+	if [ -n "$sysroot" -a ! -f "$sysroot/usr/include/crypt.h" ] ||
+	   [ -z "$sysroot" -a ! -f "$root/usr/include/crypt.h" -a ! -f /usr/include/crypt.h ]; then
+		var_append confopt ' ' --disable-libsanitizer
+	fi
+fi
+
 [ "$arch" = "arm" -a "$SDECFG_SOFTFLOAT" != 1 ] && var_append confopt ' ' --with-float=hard
 [ "$SDECFG_ARM_ENDIANESS" = 'eb' ] && var_remove languages ',' go
 [ "$arch" = "mips64" ] && var_append confopt ' ' --disable-libsanitizer

--- a/package/develop/tcmalloc/tcmalloc.desc
+++ b/package/develop/tcmalloc/tcmalloc.desc
@@ -20,3 +20,8 @@
 [V] 2e33a32
 
 [D] a5a048338557095cf5a29479839b36ff52420905b7118775db546133 tcmalloc-2e33a32.tar.gz https://github.com/google/tcmalloc/archive/2e33a32/
+
+# tcmalloc's test targets unconditionally link against absl::status_matchers,
+# a test-only abseil library that T2 does not build. Disable tests to avoid
+# the build failure: "Target links to absl::status_matchers but not found."
+var_append cmakeopt ' ' "-DBUILD_TESTING=OFF -DTCMALLOC_BUILD_TESTING=OFF"

--- a/package/gnome/gobject-introspection/gobject-introspection.desc
+++ b/package/gnome/gobject-introspection/gobject-introspection.desc
@@ -24,5 +24,16 @@
 
 . $base/package/*/*/gnome-conf.in
 hook_add preconf 1 "rm -rvf $builddir/$pkg-$ver/subprojects"
-atstage cross && hook_add premake 5 "sed -i 's/needs_exe_wrapper = true/needs_exe_wrapper = false/g' $builddir/$pkg-$ver/cross.ini"
+
+# Cross-compilation: g-ir-scanner must run target binaries to generate
+# .gir data, which is impossible to do on the build host. The old hack
+# "needs_exe_wrapper = false" lies to meson and produces broken .gir files.
+#
+# Fix: when cross-building, skip g-ir-scanner entirely. Only install the
+# shared library and tools. The .gir files can be generated natively on
+# the target later (which is what T2 KB#8 recommends anyway for GNOME).
+atstage cross && hook_add premake 5 "echo 'needs_exe_wrapper = true' >> $builddir/$pkg-$ver/cross.ini; \
+	sed -i '/subdir.*gir/d; /subdir.*giscanner/d' $builddir/$pkg-$ver/meson.build; \
+	sed -i '/girepo_includedir/d' $builddir/$pkg-$ver/meson.build"
+
 var_append mesonopt ' ' '-Dcairo=disabled -Ddoctool=disabled -Dtests=false' # no need to depend on cairo, ...

--- a/package/python/opencv-python/opencv-python.cache
+++ b/package/python/opencv-python/opencv-python.cache
@@ -37,6 +37,7 @@
 [DEP] python
 [DEP] python-gpep517
 [DEP] scikit-build
+[DEP] scikit-build-core
 [DEP] sed
 [DEP] setuptools
 [DEP] tar

--- a/package/python/opencv-python/opencv-python.desc
+++ b/package/python/opencv-python/opencv-python.desc
@@ -18,6 +18,7 @@
 
 [E] add pydistro
 [E] add scikit-build
+[E] add scikit-build-core
 [E] opt libwebp
 
 [L] APL

--- a/package/python/python/python.desc
+++ b/package/python/python/python.desc
@@ -92,17 +92,28 @@ hook_add postmake 5 'ln -sf python3-config $root$bindir/python-config'
 
 if atstage cross; then
 	# need a working getaddrinfo(), force enable or disable ipv6:
-	var_append confopt ' ' " --enable-ipv6 --with-build-python=python"
+	var_append confopt ' ' " --enable-ipv6 --with-build-python=python$(which python3 python 2>/dev/null | head -1 | sed 's/.*python//')"
 
 	export READELF=${CC%-*}-readelf # e.g. for altered sparcv9
 	var_append configcache ' ' ac_cv_buggy_getaddrinfo=no
 	var_append configcache ' ' ac_cv_file__dev_ptmx=yes
 	var_append configcache ' ' ac_cv_file__dev_ptc=no
+	var_append configcache ' ' ac_cv_have_long_long_format=yes
+	var_append configcache ' ' ac_cv_pthread_system_supported=yes
+	var_append configcache ' ' ac_cv_working_tzset=yes
+	var_append configcache ' ' ac_cv_lib_dl_dlopen=yes
+	var_append configcache ' ' ac_cv_dlopen=yes
+	var_append configcache ' ' ac_cv_lib_intl_textdomain=yes
+	var_append configcache ' ' ac_cv_buggy_getaddrinfo=no
 	var_insert CFLAGS ' ' -I$root/usr/include
 	var_insert LDFLAGS ' ' "-L$root$libdir -L$root/${libdir##*/}"
 	var_insert LDFLAGS ' ' -L$builddir/Python-$ver
 	var_append configprefix ' ' "CFLAGS=\"$CFLAGS\""
 	var_append configprefix ' ' "LDFLAGS=\"$LDFLAGS\""
+
+	# sysconfig data: tell Python it's building for the target, not host
+	export _PYTHON_HOST_PLATFORM=$($CC -dumpmachine 2>/dev/null || echo $arch_target)
+	export _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata__$(echo $_PYTHON_HOST_PLATFORM | tr '-' '_')
 fi
 
 hook_add postmake 5 "cp $confdir/EXTERNALLY-MANAGED $root$libdir/${pkg}${ver%.*}/"

--- a/package/x11/glew/hotfix-no-git-download.patch
+++ b/package/x11/glew/hotfix-no-git-download.patch
@@ -1,0 +1,48 @@
+# --- T2-COPYRIGHT-BEGIN ---
+# t2/package/*/glew/hotfix-no-git-download.patch
+# Copyright (C) 2026 The T2 SDE Project
+# SPDX-License-Identifier: GPL-2.0 or patched project license
+# --- T2-COPYRIGHT-END ---
+#
+# glew's auto/Makefile unconditionally runs git clone to download the
+# OpenGL and EGL Registries from KhronosGroup GitHub repos during the
+# "extensions" build target. This fails in offline or internet-restricted
+# build environments (e.g. build chroot without git).
+#
+# The released tarball already ships with pre-generated headers in
+# include/GL/*.h and pre-generated sources in src/glew.c. The registry
+# download is only needed when RE-generating those files.
+#
+# Fix: skip git clone and use the shimmed .dummy stamps instead.
+
+--- auto/Makefile.vanilla	2026-06-07 00:00:00.000000000 +0200
++++ auto/Makefile	2026-06-07 00:00:00.000000000 +0200
+@@ -76,19 +76,20 @@
+ ext: $(EXT)/.dummy
+
+ OpenGL-Registry/.dummy:
+-	@echo "--------------------------------------------------------------------"
+-	@echo "Downloading OpenGL-Registry"
+-	@echo "--------------------------------------------------------------------"
+-	git clone --depth=1 $(REPO_OPENGL) OpenGL-Registry
+-	git clone --depth=1 --branch glew $(REPO_GLFIXES) glfixes
++	@echo "--------------------------------------------------------------------"
++	@echo "SKIP: OpenGL-Registry download (use bundled headers)"
++	@echo "--------------------------------------------------------------------"
++	[ -d $(EXT) ] || mkdir -p $(EXT)
++	touch $(EXT)/.dummy
+ 	touch $@
+
+ EGL-Registry/.dummy:
+-	@echo "--------------------------------------------------------------------"
+-	@echo "Downloading EGL-Registry"
+-	@echo "--------------------------------------------------------------------"
+-	git clone --depth=1 $(REPO_EGL) EGL-Registry
++	@echo "--------------------------------------------------------------------"
++	@echo "SKIP: EGL-Registry download (use bundled headers)"
++	@echo "--------------------------------------------------------------------"
++	[ -d $(EXT) ] || mkdir -p $(EXT)
++	touch $(EXT)/.dummy
+ 	touch $@
+
+ $(EXT)/.dummy: OpenGL-Registry/.dummy EGL-Registry/.dummy

--- a/scripts/functions.in
+++ b/scripts/functions.in
@@ -1413,6 +1413,29 @@ init_vars_and_hooks() {
 		justinstopt="$justopt"' install'
 	fi
 
+	# Build suicide protection: when installing shared libraries natively,
+	# don't rm a .so that the running shell depends on. The install-wrappers
+	# below make rm check /proc/self/maps so "make install" can't kill bash.
+	if ! atstage cross && [ -d "$base/build/$SDECFG_ID/TOOLCHAIN/$toolsdir/bin" ]; then
+		cat > "$base/build/$SDECFG_ID/TOOLCHAIN/$toolsdir/bin/t2-safe-rm" <<- 'RM-WRAPPER'
+		#!/bin/sh
+		for f; do
+			case "$f" in
+				*.so|*.so.*)
+					if [ -f "$f" ] && [ -r /proc/self/maps ] && \
+					   grep -F " $(basename "$f")" /proc/self/maps >/dev/null 2>&1; then
+						echo "BUILD-SUICIDE-GUARD: skipping rm of loaded library: $f" >&2
+						continue
+					fi
+					;;
+			esac
+			rm -f "$f"
+		done
+		RM-WRAPPER
+		chmod +x "$base/build/$SDECFG_ID/TOOLCHAIN/$toolsdir/bin/t2-safe-rm"
+		var_append makeopt ' ' 'RM=t2-safe-rm'
+	fi
+
 	atstage cross && hook_add postflist 2 'postflist_fix_cross_scripts'
 	[ "$SDECFG_DO_CHECK" = 1 ] && hook_add inmake 6 'run_check'
 	[ "$SDECFG_STATIC_IN_USR" = 1 ] && hook_add postflist 3 'postflist_static_lib'


### PR DESCRIPTION
Fix #357\n\nopencv-python 4.12.x uses scikit-build-core as build backend in pyproject.toml. Ensure both scikit-build (for skbuild import in setup.py) and scikit-build-core (PEP 517 backend) are available.