### PR TITLE
fix opentegra undefined symbol by loading fb and shadow

### DIFF
--- a/package/xorg/xorg-server/xorg.conf.template
+++ b/package/xorg/xorg-server/xorg.conf.template
@@ -8,6 +8,8 @@ EndSection
 Section "Module"
     Load        "dbe"
     Load	"ddc"
+    Load        "fb"
+    Load        "shadow"
 
     SubSection  "extmod"
       # Option    "omit xfree86-dga"


### PR DESCRIPTION
Fixes #312.

Xorg config loads fb and shadow before opentegra, so libshadow.so is loaded when opentegra_drv.so needs shadowUpdatePacked. 