### PR TITLE
fix confdialog build error from fprintf format string

### DIFF
--- a/misc/confdialog/confdialog.c
+++ b/misc/confdialog/confdialog.c
@@ -219,7 +219,7 @@ j_inputbox (const char *t, int ac, const char * const * av)
     int ret = dialog_inputbox (t, av[2], atoi (av[3]), atoi (av[4]),
                             ac == 6 ? av[5] : (char *) NULL);
     if (ret == 0)
-        fprintf(stderr, dialog_input_result);
+        fprintf(stderr, "%s", dialog_input_result);
     return ret;
 }
 


### PR DESCRIPTION
Fix gcc `[-Werror=format-security]` error from unsafe `fprintf` format string.

```
/tmp/confdialog-test/confdialog.c:222:25: error: format not a string literal and no format arguments [-Werror=format-security]
  222 |         fprintf(stderr, dialog_input_result);
      |                         ^~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
```