### PR TITLE
mark docs deps optional for more packages

### DIFF
--- a/package/archiver/gcab/gcab.desc
+++ b/package/archiver/gcab/gcab.desc
@@ -16,10 +16,13 @@
 [C] extra/archive
 [F] CROSS
 
+[E] opt gtk-doc docbook-xml docbook-xsl libxslt
+
 [L] GPL
 [V] 1.6
 [P] X -----5---9 108.200
 
 [D] d498ca9a873cf430ae1f1d7d4571ca07523e1a1469d31e3a573d217a gcab-1.6.tar.gz https://github.com/GNOME/gcab/archive/v1.6/
 
+pkginstalled gtk-doc docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Ddocs=false
 #var_append mesonopt ' ' -Dintrospection=false

--- a/package/audio/playerctl/playerctl.desc
+++ b/package/audio/playerctl/playerctl.desc
@@ -18,10 +18,13 @@
 [C] extra/multimedia
 [F] CROSS
 
+[E] opt gtk-doc docbook-xml docbook-xsl
+
 [L] LGPL
 [V] 2.4.1
 [P] X -----5---9 400.000
 
 [D] 214e4b05a591c71f5558a379d2623f8c035802d1d4c05e4c059bab63 playerctl-2.4.1.tar.gz https://github.com/altdesktop/playerctl/archive/v2.4.1/
 
+pkginstalled gtk-doc docbook-xml docbook-xsl || var_append mesonopt ' ' -Dgtk-doc=false
 pkginstalled gobject-introspection || var_append mesonopt ' ' -Dintrospection=false

--- a/package/gnome/appstream-glib/appstream-glib.desc
+++ b/package/gnome/appstream-glib/appstream-glib.desc
@@ -14,6 +14,8 @@
 
 [C] extra/game extra/desktop/gnome
 
+[E] opt docbook-xml docbook-xsl libxslt
+
 [L] GPL
 [V] 0.8.3
 [P] X -----5---9 486.000
@@ -21,4 +23,5 @@
 [D] cc5492ce990d7c2a8a896f028fd6e75424bab733cca368d0f488181c appstream-glib-0.8.3.tar.xz https://people.freedesktop.org/~hughsient/appstream-glib/releases/
 
 . $base/package/*/*/gnome-conf.in
+pkginstalled docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Dman=false
 pkginstalled rpm || var_append mesonopt ' ' -Drpm=false

--- a/package/gnome/gnome-session/gnome-session.desc
+++ b/package/gnome/gnome-session/gnome-session.desc
@@ -18,6 +18,8 @@
 
 [C] extra/base extra/desktop/gnome
 
+[E] opt docbook-xml docbook-xsl libxml libxslt xmlto
+
 [L] LGPL
 [V] 50.0
 [P] X -----5---9 186.300
@@ -26,3 +28,4 @@
 [D] 94973828a8db4bf02ca324006c8b8fbc80de575c026e5569e61b9628 gnome-session-50.0.tar.xz https://download.gnome.org/sources/gnome-session/50/
 
 . $base/package/*/*/gnome-conf.in
+pkginstalled docbook-xml docbook-xsl libxml libxslt xmlto || var_append mesonopt ' ' '-Ddocbook=false -Dman=false'


### PR DESCRIPTION
Related to #390

## Summary
- mark documentation/manpage toolchains as optional for playerctl, gcab, appstream-glib, and gnome-session
- disable the corresponding Meson docs/man features when those toolchains are not installed
- align the package metadata with the current doc-related cache behavior instead of treating those tools as unconditional build requirements

## Why
Issue #390 tracks packages whose docs/man dependencies are effectively optional but are not declared that way in the package metadata. These four packages expose upstream Meson toggles for the affected docs/man paths, so the package recipes can safely gate them behind installed tooling.

## Validation
- scripts/Check-PkgFormat playerctl
- scripts/Check-PkgFormat gcab
- scripts/Check-PkgFormat appstream-glib
- scripts/Check-PkgFormat gnome-session