### PR TITLE
mark more doc deps optional

### DIFF
--- a/package/budgie/budgie-session/budgie-session.desc
+++ b/package/budgie/budgie-session/budgie-session.desc
@@ -15,10 +15,13 @@
 
 [C] extra/desktop/gnome
 
+[E] opt docbook-xml docbook-xsl libxslt
+
 [L] GPL
 [V] 1.0.1
 
 [D] f85f0a048cda5bdca7dfd539392ba709fb316fb2b7f177cf19f9467c budgie-session-1.0.1.tar.gz https://github.com/BuddiesOfBudgie/budgie-session/archive/refs/tags/v1.0.1/
 
+pkginstalled docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Dman=false
 pkginstalled systemd || var_append mesonopt ' ' -Dsystemd=false
 pkginstalled systemd || var_append mesonopt ' ' -Dsystemd_journal=false

--- a/package/emulators/flatpak/flatpak.desc
+++ b/package/emulators/flatpak/flatpak.desc
@@ -21,9 +21,14 @@
 [V] 1.16.6
 [P] X -----5---9 500.000
 
+[E] opt gtk-doc docbook-xml docbook-xsl libxslt xmlto
+
 [CV-FLAGS] ODD-UNSTABLE
 [D] cc061df0a698d79a9545267a8a113c571f8ce1152dd983cd5f30ddeb flatpak-1.16.6.tar.gz https://github.com/flatpak/flatpak/archive/refs/tags/1.16.6/
 
 var_append mesonopt ' ' -Dtests=false
+pkginstalled gtk-doc docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Dgtkdoc=disabled
+pkginstalled docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Dman=disabled
+pkginstalled xmlto docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Ddocbook_docs=disabled
 pkginstalled bubblewrap && var_append mesonopt ' ' -Dsystem_bubblewrap=bwrap
 pkginstalled polkit || var_append mesonopt ' ' -Dsystem_helper=disabled


### PR DESCRIPTION
Related to #390

## Summary
- mark Flatpak's gtk-doc, manpage, and docbook/html documentation toolchains as optional
- mark budgie-session's manpage toolchain as optional
- disable the corresponding Meson documentation features when the required docbook tooling is not installed

## Why
This is a second small pass for #390. Both packages currently record doc-related tooling in their build cache, but upstream already exposes Meson switches that allow those documentation paths to be skipped cleanly.

## Validation
- scripts/Check-PkgFormat flatpak
- scripts/Check-PkgFormat budgie-session