### PR TITLE
mark gtk-doc optional for libnma and phodav

### DIFF
--- a/package/gnome/libnma/libnma.desc
+++ b/package/gnome/libnma/libnma.desc
@@ -19,7 +19,10 @@
 [V] 1.10.6
 [P] X -----5---9 177.200
 
+[E] opt gtk-doc docbook-xml docbook-xsl
+
 [CV-URL] https://download.gnome.org/sources/libnma/cache.json
 [D] cb49f8c60826eb0a8ba23ad4b3a1d38fdab3b0493ff301d1e0d08b20 libnma-1.10.6.tar.xz https://download.gnome.org/sources/libnma/1.10/
 
 . $base/package/*/*/gnome-conf.in
+pkginstalled gtk-doc docbook-xml docbook-xsl || var_append mesonopt ' ' -Dgtk_doc=false

--- a/package/gnome/phodav/phodav.desc
+++ b/package/gnome/phodav/phodav.desc
@@ -18,7 +18,10 @@
 [L] LGPL
 [V] 3.0
 
+[E] opt gtk-doc
+
 [CV-URL] https://download.gnome.org/sources/phodav/cache.json
 [D] 0d3fb48d5c95cc833c4ce25af4493aa73b7bf62c7e059129d81e33ae phodav-3.0.tar.xz https://download.gnome.org/sources/phodav/3.0/
 
 . $base/package/*/*/gnome-conf.in
+pkginstalled gtk-doc || var_append mesonopt ' ' -Dgtk_doc=disabled


### PR DESCRIPTION
Related to #390

## Summary
- mark `gtk-doc` as an optional dependency for `libnma` and `phodav`
- disable each package's gtk-doc documentation path when the required tooling is not installed
- keep the package metadata aligned with the current doc-related cache entries instead of treating gtk-doc as an unconditional build dependency

## Why
This is another narrow pass for #390. Both packages record `gtk-doc` in their build cache, and upstream already exposes a dedicated Meson gtk-doc toggle for that documentation path.

## Validation
- `git diff --check`
- `scripts/Check-PkgFormat libnma`
- `scripts/Check-PkgFormat phodav`

## Notes
- In this pass I limited `phodav` to the upstream-explicit `gtk_doc` option and did not touch its auto-detected manpage toolchain.