### PR TITLE
mark more manpage deps optional

### DIFF
--- a/package/gnome/localsearch/localsearch.desc
+++ b/package/gnome/localsearch/localsearch.desc
@@ -23,10 +23,13 @@
 [L] GPL
 [V] 3.11.1
 
+[E] opt asciidoc docbook-xml docbook-xsl libxslt
+
 [CV-URL] https://download.gnome.org/sources/localsearch/cache.json
 [D] e6d7c18f9ceaece9191f1cc2f8cdfffe6a6891369ded52ccba0695bb localsearch-3.11.1.tar.xz https://download.gnome.org/sources/localsearch/3.11/
 
 . $base/package/*/*/gnome-conf.in
+pkginstalled asciidoc docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Dman=false
 pkginstalled systemd || var_append mesonopt ' ' -Dsystemd_user_services=false
 pkginstalled upower || var_append mesonopt ' ' -Dbattery_detection=none
 var_append mesonopt ' ' -Dlandlock=disabled

--- a/package/gnome/tinysparql/tinysparql.desc
+++ b/package/gnome/tinysparql/tinysparql.desc
@@ -23,8 +23,11 @@
 [V] 3.11.1
 [P] X -----5---9 185.500
 
+[E] opt asciidoc docbook-xml docbook-xsl libxslt
+
 [CV-URL] https://download.gnome.org/sources/tinysparql/cache.json
 [D] 911a6fe1ce5a854557ba60cc0495b148c62e09e8c64db1d809b7bd29 tinysparql-3.11.1.tar.xz https://download.gnome.org/sources/tinysparql/3.11/
 
 . $base/package/*/*/gnome-conf.in
+pkginstalled asciidoc docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Dman=false
 pkginstalled systemd || var_append mesonopt ' ' -Dsystemd_user_services=false


### PR DESCRIPTION
Related to #390

## Summary
- mark the manpage toolchains for `localsearch` and `tinysparql` as optional
- disable manpage installation when the required AsciiDoc/docbook toolchain is not installed
- align both package recipes with the current cache behavior instead of treating manpage generation tools as unconditional build requirements

## Why
This is another narrow pass for #390. Both packages currently record AsciiDoc/docbook manpage tooling in their build cache, and upstream already exposes a dedicated `man` Meson option for those install paths.

## Validation
- `git diff --check`
- `scripts/Check-PkgFormat localsearch`
- `scripts/Check-PkgFormat tinysparql`

## Notes
- I intentionally limited `tinysparql` to its manpage toolchain. Its docs path has a separate pre-generated tarball branch, so I did not broaden this PR into API-doc handling.