### PR TITLE
mark more gnome doc deps optional

### DIFF
--- a/package/gnome/gnome-keyring/gnome-keyring.desc
+++ b/package/gnome/gnome-keyring/gnome-keyring.desc
@@ -27,8 +27,11 @@
 [V] 50.0
 [P] X -----5---9 142.100
 
+[E] opt docbook-xml docbook-xsl libxslt
+
 [CV-URL] https://download.gnome.org/sources/gnome-keyring/cache.json
 [D] 26559beb0240f6964c964453061351851ac4e02878b8a4b1c19d8e23 gnome-keyring-50.0.tar.xz https://download.gnome.org/sources/gnome-keyring/50/
 
 . $base/package/*/*/gnome-conf.in
+pkginstalled docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Dmanpage=false
 pkginstalled systemd || var_append mesonopt ' ' -Dsystemd=disabled

--- a/package/gnome/gnome-online-accounts/gnome-online-accounts.desc
+++ b/package/gnome/gnome-online-accounts/gnome-online-accounts.desc
@@ -21,9 +21,13 @@
 [V] 3.58.1
 [P] X -----5---9 200.100
 
+[E] opt docbook-xml docbook-xsl gi-docgen libxslt
+
 [CV-URL] https://download.gnome.org/sources/gnome-online-accounts/cache.json
 [D] 08eaf00dc3a221f6c93402b6aab1771740b22ddc6bf3e13f49ee92ec gnome-online-accounts-3.58.1.tar.xz https://download.gnome.org/sources/gnome-online-accounts/3.58/
 
 . $base/package/*/*/gnome-conf.in
 
+pkginstalled gi-docgen || var_append mesonopt ' ' -Ddocumentation=false
+pkginstalled docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Dman=false
 pkginstalled krb5 || var_append mesonopt ' ' -Dkerberos=false


### PR DESCRIPTION
Related to #390

## Summary
- mark the doc/man tooling for `gnome-keyring` and `gnome-online-accounts` as optional
- disable the corresponding documentation paths when the required tooling is not installed
- keep both package recipes aligned with the current cache behavior instead of treating those documentation tools as unconditional build requirements

## Why
This is another narrow pass for #390. `gnome-keyring` exposes a dedicated `manpage` Meson option, and `gnome-online-accounts` exposes separate `documentation` and `man` options for its API docs and manpage path.

## Validation
- `git diff --check`
- `scripts/Check-PkgFormat gnome-keyring`
- `scripts/Check-PkgFormat gnome-online-accounts`

## Notes
- I kept `gnome-online-accounts` scoped to docs/man toolchains only and did not broaden this PR into unrelated feature toggles such as introspection.