### PR TITLE
mark more doc deps optional

### DIFF
--- a/package/develop/libostree/libostree.desc
+++ b/package/develop/libostree/libostree.desc
@@ -21,6 +21,7 @@
 
 [E] opt libsoup
 [E] opt libsoup3
+[E] opt gtk-doc docbook-xml docbook-xsl libxslt
 
 [L] LGPL
 [V] 2026.1
@@ -31,4 +32,4 @@
 pkginstalled gobject-introspection || var_append confopt ' ' --with-introspection=no
 pkginstalled libselinux || var_append confopt ' ' --without-selinux
 pkginstalled systemd || var_append confopt ' ' --without-libsystemd
-pkginstalled gtk-doc && var_append confopt ' ' --enable-gtk-doc
+pkginstalled gtk-doc docbook-xml docbook-xsl libxslt && var_append confopt ' ' --enable-gtk-doc

--- a/package/gnome/gnome-terminal/gnome-terminal.desc
+++ b/package/gnome/gnome-terminal/gnome-terminal.desc
@@ -16,6 +16,8 @@
 
 [C] extra/shell extra/desktop/gnome
 
+[E] opt docbook-xml docbook-xsl libxslt
+
 [L] LGPL
 [V] 3.60.0
 
@@ -23,5 +25,5 @@
 [D] 88362fc24d5242161090b91ce7fe26d400360de95c83822d2c1cd991 gnome-terminal-3.60.0.tar.xz https://download.gnome.org/sources/gnome-terminal/3.60/
 
 . $base/package/*/*/gnome-conf.in
-pkginstalled docbook-xml docbook-xsl || var_append mesonopt ' ' -Ddocs=false
+pkginstalled docbook-xml docbook-xsl libxslt || var_append mesonopt ' ' -Ddocs=false
 pkginstalled nautilus || var_append mesonopt ' ' -Dnautilus_extension=false


### PR DESCRIPTION
- mark libostree gtk-doc dependencies optional by enabling docs only when gtk-doc and the required docbook/libxslt tools are present
- mark gnome-terminal doc generation dependencies optional and disable docs when libxslt is missing

Refs #390