### PR TITLE
mark additional doc deps optional

### DIFF
--- a/package/audio/alsa-utils/alsa-utils.desc
+++ b/package/audio/alsa-utils/alsa-utils.desc
@@ -18,6 +18,8 @@
 [C] base/system base/kernel
 [F] CROSS
 
+[E] opt xmlto
+
 [L] GPL
 [V] 1.2.15.2
 [P] X -----5---9 158.500

--- a/package/base/upower/upower.desc
+++ b/package/base/upower/upower.desc
@@ -19,7 +19,7 @@
 [C] extra/development
 [F] CROSS NO-LTO.clang
 
-[E] opt libxslt docbook-xml docbook-xsl
+[E] opt gtk-doc libxslt docbook-xml docbook-xsl
 [E] opt gobject-introspection
 
 [L] GPL


### PR DESCRIPTION
- mark alsa-utils xmlto support as optional to match the existing build toggle and cache metadata
- add missing gtk-doc optional metadata for upower to match the existing docs toggle

Refs #390