### PR TITLE
mark remaining doc deps optional

### DIFF
--- a/package/gnome/libsoup3/libsoup3.desc
+++ b/package/gnome/libsoup3/libsoup3.desc
@@ -22,6 +22,7 @@
 [F] CROSS
 
 [E] add smartypants
+[E] opt gi-docgen
 
 [L] LGPL
 [V] 3.6.6

--- a/package/network/libqrtr/libqrtr.desc
+++ b/package/network/libqrtr/libqrtr.desc
@@ -17,6 +17,8 @@
 [C] extra/base
 [F] CROSS
 
+[E] opt gtk-doc
+
 [V] 1.4.0
 [L] LGPL
 [P] X -----5---9 127.000


### PR DESCRIPTION
- mark libsoup3 gi-docgen documentation support as optional to match the existing docs toggle and cache metadata
- mark libqrtr gtk-doc support as optional to match the existing docs toggle and cache metadata

Refs #390