### PR TITLE
mark more gi-docgen deps optional

### DIFF
--- a/package/gnome/libsecret/libsecret.desc
+++ b/package/gnome/libsecret/libsecret.desc
@@ -19,6 +19,8 @@
 [C] extra/shell extra/desktop/gnome
 [F] CROSS
 
+[E] opt gi-docgen libxslt docbook-xml docbook-xsl
+
 [L] LGPL
 [V] 0.21.7
 [P] X -----5---9 179.200

--- a/package/gnome/libshumate/libshumate.desc
+++ b/package/gnome/libshumate/libshumate.desc
@@ -16,6 +16,8 @@
 [C] extra/tool
 [F] CROSS
 
+[E] opt gi-docgen
+
 [L] LGPL
 [V] 1.6.1
 


### PR DESCRIPTION
- mark libsecret documentation dependencies optional to match the existing gi-docgen and manpage toggles
- mark libshumate gi-docgen documentation support optional to match the existing gtk_doc toggle

Refs #390