### PR TITLE
mark more doc metadata optional

### DIFF
--- a/package/develop/trace-cmd/trace-cmd.desc
+++ b/package/develop/trace-cmd/trace-cmd.desc
@@ -18,6 +18,8 @@
 
 [C] base/tool
 
+[E] opt xmlto
+
 [L] GPL
 [V] 3.4
 

--- a/package/gnome/gspell/gspell.desc
+++ b/package/gnome/gspell/gspell.desc
@@ -15,6 +15,8 @@
 
 [C] extra/shell extra/desktop/gnome
 
+[E] opt gtk-doc docbook-xml docbook-xsl
+
 [L] LGPL
 [V] 1.14.3
 [P] X -----5---9 177.200


### PR DESCRIPTION
- mark gspell gtk-doc and docbook documentation dependencies optional to match the existing gtk_doc toggle and cache metadata
- mark trace-cmd xmlto documentation support optional to match the existing doc toggle and cache metadata

Refs #390