### PR TITLE
mark more docs tooling optional

### DIFF
--- a/package/develop/libnotify/libnotify.desc
+++ b/package/develop/libnotify/libnotify.desc
@@ -18,7 +18,7 @@
 [C] extra/development
 [F] CROSS
 
-[E] opt gtk-doc gi-docgen docbook-xml docbook-xsl libxml libxslt
+[E] opt gtk-doc gi-docgen docbook-xml docbook-xsl libxml libxslt xmlto
 
 [L] GPL
 [V] 0.8.8

--- a/package/develop/libtraceevent/libtraceevent.desc
+++ b/package/develop/libtraceevent/libtraceevent.desc
@@ -17,6 +17,7 @@
 [C] base/tool
 [F] CROSS
 
+[E] opt asciidoc
 [E] opt cunit
 
 [L] GPL


### PR DESCRIPTION
- add missing xmlto optional metadata for libnotify to match the existing docbook_docs toggle and cache metadata
- add missing asciidoc optional metadata for libtraceevent to match the existing doc toggle and cache metadata

Refs #390