### PR TITLE
mark gtk-doc metadata optional

### DIFF
--- a/package/firmware/libosinfo/libosinfo.desc
+++ b/package/firmware/libosinfo/libosinfo.desc
@@ -16,6 +16,7 @@
 [C] extra/base
 [F] CROSS
 
+[E] opt gtk-doc docbook-xml docbook-xsl
 [E] opt vala
 
 [V] 1.12.0

--- a/package/textproc/libxmlb/libxmlb.desc
+++ b/package/textproc/libxmlb/libxmlb.desc
@@ -16,6 +16,8 @@
 [C] base/library
 [F] CROSS
 
+[E] opt gtk-doc docbook-xml docbook-xsl
+
 [L] LGPL
 [V] 0.3.26
 [P] X -----5---9 161.645


### PR DESCRIPTION
- add missing gtk-doc and docbook optional metadata for libosinfo to match the existing enable-gtk-doc toggle and cache metadata
- add missing gtk-doc and docbook optional metadata for libxmlb to match the existing gtkdoc toggle and cache metadata

Refs #390