### PR TITLE
mark more docs packages optional

### DIFF
--- a/package/gnome/gdk-pixbuf/gdk-pixbuf.desc
+++ b/package/gnome/gdk-pixbuf/gdk-pixbuf.desc
@@ -24,6 +24,8 @@
 [F] CROSS
 
 [E] add shared-mime-info
+[E] opt docutils
+[E] opt gtk-doc
 [E] opt libjpeg
 [E] opt libpng
 

--- a/package/graphic/colord/colord.desc
+++ b/package/graphic/colord/colord.desc
@@ -18,6 +18,8 @@
 [C] extra/multimedia
 [F] CROSS
 
+[E] opt gtk-doc
+
 [L] GPL
 [V] 1.4.8
 [P] X -----5---9 130.050


### PR DESCRIPTION
- add missing gtk-doc optional metadata for colord to match the existing docs toggle and cache metadata
- add missing docutils and gtk-doc optional metadata for gdk-pixbuf to match the existing man and gtk_doc toggles and cache metadata

Refs #390