### PR TITLE
mark remaining opt deps

### DIFF
--- a/package/containers/lxc/lxc.desc
+++ b/package/containers/lxc/lxc.desc
@@ -19,6 +19,7 @@
 [F] CROSS
 
 [E] opt docbook2x
+[E] opt docbook-xml docbook-xsl libxslt
 [E] opt perl-sax-exception perl-sax-parser perl-xml-namespace-support
 
 [L] GPL

--- a/package/gnome/libsoup3/libsoup3.desc
+++ b/package/gnome/libsoup3/libsoup3.desc
@@ -28,6 +28,7 @@
 [P] X -----5---9 149.499
 
 [E] add markdown
+[E] opt vala
 [E] opt graphviz
 [E] del valgrind
 


### PR DESCRIPTION
- add missing docbook-xml, docbook-xsl, and libxslt optional metadata for lxc to match the existing manpage toggle and cache metadata
- add missing vala optional metadata for libsoup3 to match the existing vapi toggle and cache metadata

Refs #390