### PR TITLE
mark introspection deps optional

### DIFF
--- a/package/audio/playerctl/playerctl.desc
+++ b/package/audio/playerctl/playerctl.desc
@@ -18,6 +18,8 @@
 [C] extra/multimedia
 [F] CROSS
 
+[E] opt gobject-introspection
+
 [L] LGPL
 [V] 2.4.1
 [P] X -----5---9 400.000

--- a/package/textproc/libxmlb/libxmlb.desc
+++ b/package/textproc/libxmlb/libxmlb.desc
@@ -16,6 +16,8 @@
 [C] base/library
 [F] CROSS
 
+[E] opt gobject-introspection
+
 [L] LGPL
 [V] 0.3.26
 [P] X -----5---9 161.645


### PR DESCRIPTION
- add missing gobject-introspection optional metadata for playerctl to match the existing introspection toggle and cache metadata
- add missing gobject-introspection optional metadata for libxmlb to match the existing introspection toggle and cache metadata

Refs #390