### PR TITLE
mark more optional runtime deps

### DIFF
--- a/package/gnome/glib-networking/glib-networking.desc
+++ b/package/gnome/glib-networking/glib-networking.desc
@@ -18,6 +18,7 @@
 [F] CROSS
 
 [E] add jinja2 typogrify
+[E] opt openssl
 
 [L] LGPL
 [V] 2.80.1

--- a/package/gnome/json-glib/json-glib.desc
+++ b/package/gnome/json-glib/json-glib.desc
@@ -16,6 +16,8 @@
 [C] extra/development
 [F] CROSS
 
+[E] opt gobject-introspection
+
 [L] LGPL
 [V] 1.10.8
 [P] X -----5---9 155.050


### PR DESCRIPTION
- add missing gobject-introspection optional metadata for json-glib to match the existing introspection toggle and cache metadata
- add missing openssl optional metadata for glib-networking to match the existing openssl toggle and cache metadata

Refs #390