### PR TITLE
mark more optional package deps

### DIFF
--- a/package/audio/pavucontrol/pavucontrol.desc
+++ b/package/audio/pavucontrol/pavucontrol.desc
@@ -19,6 +19,8 @@
 [C] extra/multimedia
 [F] CROSS
 
+[E] opt lynx
+
 [L] GPL
 [V] 6.2
 

--- a/package/gnome/enchant/enchant.desc
+++ b/package/gnome/enchant/enchant.desc
@@ -22,6 +22,7 @@
 [F] CROSS
 
 [E] opt aspell
+[E] opt hunspell
 
 [L] LGPL
 [V] 2.8.16


### PR DESCRIPTION
- add missing lynx optional metadata for pavucontrol to match the existing lynx toggle and cache metadata
- add missing hunspell optional metadata for enchant to match the existing system-myspell toggle and cache metadata

Refs #390