### PR TITLE
mark more gi opt deps

### DIFF
--- a/package/gnome/gsettings-desktop-schemas/gsettings-desktop-schemas.desc
+++ b/package/gnome/gsettings-desktop-schemas/gsettings-desktop-schemas.desc
@@ -17,6 +17,8 @@
 [C] extra/base extra/desktop/gnome
 [F] CROSS
 
+[E] opt gobject-introspection
+
 [L] LGPL
 [V] 50.1
 [P] X -----5---9 127.350

--- a/package/gnome/libwnck/libwnck.desc
+++ b/package/gnome/libwnck/libwnck.desc
@@ -17,6 +17,8 @@
 [C] extra/development extra/desktop/gnome
 [F] CROSS
 
+[E] opt gobject-introspection
+
 [L] LGPL
 [V] 43.3
 [P] X -----5---9 202.000


### PR DESCRIPTION
- add missing gobject-introspection optional metadata for gsettings-desktop-schemas to match the existing introspection toggle and cache metadata
- add missing gobject-introspection optional metadata for libwnck to match the existing introspection toggle and cache metadata

Refs #390