### PR TITLE
mark more gi deps optional

### DIFF
--- a/package/gnome/libsoup/libsoup.desc
+++ b/package/gnome/libsoup/libsoup.desc
@@ -22,6 +22,7 @@
 
 [E] opt apache
 [E] opt brotli
+[E] opt gobject-introspection
 [E] opt unwind
 
 [L] LGPL

--- a/package/gnome/pango/pango.desc
+++ b/package/gnome/pango/pango.desc
@@ -22,6 +22,8 @@
 [C] extra/text
 [F] CROSS
 
+[E] opt gobject-introspection
+
 [L] GPL
 [V] 1.57.1
 [P] X -----5---9 150.050


### PR DESCRIPTION
- add missing gobject-introspection optional metadata for pango to match the existing introspection toggle and cache metadata
- add missing gobject-introspection optional metadata for libsoup to match the existing introspection toggle and cache metadata

Refs #390