### PR TITLE
mark more optional feature deps

### DIFF
--- a/package/gnome/gnome-settings-daemon/gnome-settings-daemon.desc
+++ b/package/gnome/gnome-settings-daemon/gnome-settings-daemon.desc
@@ -15,6 +15,8 @@
 
 [C] extra/base extra/desktop/gnome
 
+[E] opt systemd
+
 [L] LGPL
 [V] 50.1
 [P] X -----5---9 185.400

--- a/package/gnome/hexchat/hexchat.desc
+++ b/package/gnome/hexchat/hexchat.desc
@@ -20,6 +20,8 @@
 [C] extra/network
 [F] CROSS
 
+[E] opt openssl
+
 [L] GPL
 [V] 2.16.2
 


### PR DESCRIPTION
- add missing systemd optional metadata for gnome-settings-daemon to match the existing systemd toggle and cache metadata
- add missing openssl optional metadata for hexchat to match the existing openssl toggle and cache metadata

Refs #390