### PR TITLE
mark more introspection metadata optional

### DIFF
--- a/package/gnome/libmanette/libmanette.desc
+++ b/package/gnome/libmanette/libmanette.desc
@@ -25,6 +25,7 @@
 [L] LGPL
 [V] 0.2.13
 [P] X -----5---9 209.700
+[E] opt gobject-introspection vala
 
 [D] 453efba87454545c88dfa645906cfcdebcaf0a36efd3a9a10e9766b0 libmanette-0.2.13.tar.xz https://download.gnome.org/sources/libmanette/0.2/
 

--- a/package/gnome/libpanel/libpanel.desc
+++ b/package/gnome/libpanel/libpanel.desc
@@ -22,6 +22,7 @@
 [L] LGPL
 [V] 1.10.4
 [P] X -----5---9 200.000
+[E] opt gobject-introspection vala
 
 [D] 89c541ddae089d8f803e1f9ce4823916c5cea120d4e8bc70a1c2187e libpanel-1.10.4.tar.xz https://download.gnome.org/sources/libpanel/1.10/
 


### PR DESCRIPTION
- add missing optional metadata for `gobject-introspection` and `vala` in `libmanette` to match the existing Meson feature toggles and package cache
- add missing optional metadata for `gobject-introspection` and `vala` in `libpanel` to match the existing Meson feature toggles and package cache

Refs #390