### PR TITLE
mark gexiv2 feature deps optional

### DIFF
--- a/package/gnome/gexiv2-014/gexiv2-014.desc
+++ b/package/gnome/gexiv2-014/gexiv2-014.desc
@@ -19,6 +19,7 @@
 [V] 0.14.6
 [L] GPL
 [P] X -----5---9 154.800
+[E] opt python pygobject gobject-introspection vala
 
 [CV-FLAGS] NO-MAJOR
 [D] 17d711b05b7e86c26d417dccb50b6ed7e358e8824a64ed002107041b gexiv2-gexiv2-0.14.6.tar.bz2 https://gitlab.gnome.org/GNOME/gexiv2/-/archive/gexiv2-0.14.6/

--- a/package/gnome/gexiv2/gexiv2.desc
+++ b/package/gnome/gexiv2/gexiv2.desc
@@ -19,6 +19,7 @@
 [V] 0.16.0
 [L] GPL
 [P] X -----5---9 154.800
+[E] opt python pygobject gobject-introspection vala
 
 [CV-FLAGS] NO-MAJOR
 [D] 3f9d1607e36bec73d6d8d8289b0c8a1776a9b69bc83cd69971074b60 gexiv2-0.16.0.tar.bz2 https://gitlab.gnome.org/GNOME/gexiv2/-/archive/0.16.0/


### PR DESCRIPTION
- add missing optional metadata for `python`, `pygobject`, `gobject-introspection`, and `vala` in `gexiv2` to match the existing Meson feature toggles and package cache
- add missing optional metadata for `python`, `pygobject`, `gobject-introspection`, and `vala` in `gexiv2-014` to match the existing Meson feature toggles and package cache

Refs #390